### PR TITLE
Add new build/check phases options for analysers, spellers, and grammar-checkers

### DIFF
--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -71,15 +71,15 @@ def create_lang_task(with_apertium):
         .with_gha(
             "deps",
             GithubAction(
-                "divvun/divvun-taskcluster-gha-test/lang/install-deps",
+                "technocreatives/divvun-taskcluster-gha-test/lang/install-deps",
                 {"sudo": "false", "apertium": with_apertium},
             ),
         )
         .with_gha(
-            "build", GithubAction("divvun/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst"})
+            "build", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst"})
         )
         .with_gha(
-            "check", GithubAction("divvun/divvun-taskcluster-gha-test/lang/check", {"fst": "hfst"}), enabled=should_make_check
+            "check", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {"fst": "hfst"}), enabled=should_make_check
         )
         .with_named_artifacts(
             "spellers",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -37,10 +37,10 @@ def create_lang_tasks(repo_name):
 
 
 def create_lang_task(with_apertium):
-    should_build_analyzers = CONFIG.tc_config.get('build', {}).get('analyzers', False)
+    should_build_analysers = CONFIG.tc_config.get('build', {}).get('analysers', False)
     should_build_spellers = CONFIG.tc_config.get('build', {}).get('spellers', False)
     should_build_grammar_checkers = CONFIG.tc_config.get('build', {}).get('grammar-checkers', False)
-    should_check_analyzers = CONFIG.tc_config.get('check', {}).get('analyzers', False)
+    should_check_analysers = CONFIG.tc_config.get('check', {}).get('analysers', False)
     should_check_spellers = CONFIG.tc_config.get('check', {}).get('spellers', False)
     should_check_grammar_checkers = CONFIG.tc_config.get('check', {}).get('grammar-checkers', False)
 
@@ -78,13 +78,13 @@ def create_lang_task(with_apertium):
             ),
         )
         .with_gha(
-            "build analyzers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "analyzers": "true", "spellers": "false"}), enabled=should_build_analyzers
+            "build analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "analysers": "true", "spellers": "false"}), enabled=should_build_analysers
         )
         .with_gha(
-            "check analyzers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analyzers
+            "check analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
         .with_gha(
-            "build spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "spellers": "true"}), enabled=should_build_analyzers
+            "build spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "spellers": "true"}), enabled=should_build_analysers
         )
         .with_gha(
             "check spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -84,16 +84,16 @@ def create_lang_task(with_apertium):
             "check analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
         .with_gha(
-            "build spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "spellers": "true"}), enabled=should_build_analysers
+            "build spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "spellers": "true"}), enabled=should_build_spellers
         )
         .with_gha(
             "check spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
         )
         .with_gha(
-            "build grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "grammar-checkers": "true"}), enabled=should_build_grammar-checkers
+            "build grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "grammar-checkers": "true"}), enabled=should_build_grammar_checkers
         )
         .with_gha(
-            "check grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar-checkers
+            "check grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )
         .with_named_artifacts(
             "spellers",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -6,7 +6,7 @@ from decisionlib import CONFIG
 from .common import linux_build_task, macos_task, windows_task, NIGHTLY_CHANNEL, gha_setup
 
 NO_DEPLOY_LANG = {
-    "zxx",  # No linguistic data
+        # "zxx",  # No linguistic data
     "est-x-plamk",
     "nno-x-ext-apertium",
 }

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -6,7 +6,7 @@ from decisionlib import CONFIG
 from .common import linux_build_task, macos_task, windows_task, NIGHTLY_CHANNEL, gha_setup
 
 NO_DEPLOY_LANG = {
-        # "zxx",  # No linguistic data
+    "zxx",  # No linguistic data
     "est-x-plamk",
     "nno-x-ext-apertium",
 }

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -71,15 +71,15 @@ def create_lang_task(with_apertium):
         .with_gha(
             "deps",
             GithubAction(
-                "divvun/taskcluster-gha/lang/install-deps",
+                "divvun/divvun-taskcluster-gha-test/lang/install-deps",
                 {"sudo": "false", "apertium": with_apertium},
             ),
         )
         .with_gha(
-            "build", GithubAction("divvun/taskcluster-gha/lang/build", {"fst": "hfst"})
+            "build", GithubAction("divvun/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst"})
         )
         .with_gha(
-            "check", GithubAction("divvun/taskcluster-gha/lang/check", {"fst": "hfst"}), enabled=should_make_check
+            "check", GithubAction("divvun/divvun-taskcluster-gha-test/lang/check", {"fst": "hfst"}), enabled=should_make_check
         )
         .with_named_artifacts(
             "spellers",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -40,7 +40,14 @@ def create_lang_task(with_apertium):
     should_make_check = False
     should_make_check = CONFIG.tc_config.get('lang', {}).get('check', False)
 
-
+#    should_build_spellers = False
+#    should_build_spellers = CONFIG.tc_config.get('lang', {}).get('spellers', False)
+#
+#    should_check_spellers = False
+#    should_check_spellers = CONFIG.tc_config.get('lang', {}).get('spellers', False)
+#
+#    should_build_grammar_checkers = False
+#    should_build_grammar_checkers = CONFIG.tc_config.get('lang', {}).get('grammar-checkers', False)
 
     return (
         linux_build_task("Lang build", bundle_dest="lang")
@@ -76,10 +83,10 @@ def create_lang_task(with_apertium):
             ),
         )
         .with_gha(
-            "build", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst"})
+            "build analyzers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "spellers": "false"})
         )
         .with_gha(
-            "check", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {"fst": "hfst"}), enabled=should_make_check
+            "check analyzers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {"fst": "hfst"}), enabled=should_make_check
         )
         .with_named_artifacts(
             "spellers",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -73,27 +73,27 @@ def create_lang_task(with_apertium):
         .with_gha(
             "deps",
             GithubAction(
-                "technocreatives/divvun-taskcluster-gha-test/lang/install-deps",
+                "divvun/taskcluster-gha/lang/install-deps",
                 {"sudo": "false", "apertium": with_apertium},
             ),
         )
         .with_gha(
-            "build analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "analysers": "true", "spellers": "false"}), enabled=should_build_analysers
+            "build analysers", GithubAction("divvun/taskcluster-gha/lang/build", {"fst": "hfst", "analysers": "true", "spellers": "false"}), enabled=should_build_analysers
         )
         .with_gha(
-            "check analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
+            "check analysers", GithubAction("divvun/taskcluster-gha/lang/check", {}), enabled=should_check_analysers
         )
         .with_gha(
-            "build spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "spellers": "true"}), enabled=should_build_spellers
+            "build spellers", GithubAction("divvun/taskcluster-gha/lang/build", {"fst": "hfst", "spellers": "true"}), enabled=should_build_spellers
         )
         .with_gha(
-            "check spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
+            "check spellers", GithubAction("divvun/taskcluster-gha/lang/check", {}), enabled=should_check_spellers
         )
         .with_gha(
-            "build grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "grammar-checkers": "true"}), enabled=should_build_grammar_checkers
+            "build grammar-checkers", GithubAction("divvun/taskcluster-gha/lang/build", {"fst": "hfst", "grammar-checkers": "true"}), enabled=should_build_grammar_checkers
         )
         .with_gha(
-            "check grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
+            "check grammar-checkers", GithubAction("divvun/taskcluster-gha/lang/check", {}), enabled=should_check_grammar_checkers
         )
         .with_named_artifacts(
             "spellers",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -37,17 +37,12 @@ def create_lang_tasks(repo_name):
 
 
 def create_lang_task(with_apertium):
-    should_make_check = False
-    should_make_check = CONFIG.tc_config.get('lang', {}).get('check', False)
-
-#    should_build_spellers = False
-#    should_build_spellers = CONFIG.tc_config.get('lang', {}).get('spellers', False)
-#
-#    should_check_spellers = False
-#    should_check_spellers = CONFIG.tc_config.get('lang', {}).get('spellers', False)
-#
-#    should_build_grammar_checkers = False
-#    should_build_grammar_checkers = CONFIG.tc_config.get('lang', {}).get('grammar-checkers', False)
+    should_build_analyzers = CONFIG.tc_config.get('build', {}).get('analyzers', False)
+    should_build_spellers = CONFIG.tc_config.get('build', {}).get('spellers', False)
+    should_build_grammar_checkers = CONFIG.tc_config.get('build', {}).get('grammar-checkers', False)
+    should_check_analyzers = CONFIG.tc_config.get('check', {}).get('analyzers', False)
+    should_check_spellers = CONFIG.tc_config.get('check', {}).get('spellers', False)
+    should_check_grammar_checkers = CONFIG.tc_config.get('check', {}).get('grammar-checkers', False)
 
     return (
         linux_build_task("Lang build", bundle_dest="lang")
@@ -83,10 +78,22 @@ def create_lang_task(with_apertium):
             ),
         )
         .with_gha(
-            "build analyzers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "spellers": "false"})
+            "build analyzers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "analyzers": "true", "spellers": "false"}), enabled=should_build_analyzers
         )
         .with_gha(
-            "check analyzers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {"fst": "hfst"}), enabled=should_make_check
+            "check analyzers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analyzers
+        )
+        .with_gha(
+            "build spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "spellers": "true"}), enabled=should_build_analyzers
+        )
+        .with_gha(
+            "check spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
+        )
+        .with_gha(
+            "build grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "grammar-checkers": "true"}), enabled=should_build_grammar-checkers
+        )
+        .with_gha(
+            "check grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar-checkers
         )
         .with_named_artifacts(
             "spellers",


### PR DESCRIPTION
This PR adds more separation and control over build steps. It is now possible to enable/disable build & check phases in a language repo's `.build-config.yml` file. 

An example `.build-config.yml` file (inside a `lang-xxx` repo) looks like this:

```yml
build:
  analysers: true
  spellers: true
  grammar-checkers: true
check:
  analysers: true
  spellers: true
  grammar-checkers: true
```

This file specifies that the following jobs should run (in order):
1. Build analysers
2. Check analysers
3. Build spellers
4. Check spellers
5. Build grammar checkers
6. Check grammar checkers

The pipeline should fail and not continue as soon as any single job fails.

