### PR TITLE
Separate lang build tasks into build (and optional check) analysers/spellers/grammar-checkers

### DIFF
--- a/decisionlib.py
+++ b/decisionlib.py
@@ -95,9 +95,9 @@ class Config:
     @property
     def index_path(self):
         if self.git_ref.startswith("refs/tags/"):
-            index = CONFIG.git_ref[len("refs/tags/") :]
+            index = CONFIG.git_ref[len("refs/tags/"):]
         elif self.git_ref.startswith("refs/heads/"):
-            index = CONFIG.git_ref[len("refs/heads/") :]
+            index = CONFIG.git_ref[len("refs/heads/"):]
         else:
             index = self.git_sha
 
@@ -122,7 +122,8 @@ class Config:
     def tc_config(self):
         if self._tc_config is None:
             try:
-                config = requests.get(f"https://raw.githubusercontent.com/{os.environ['REPO_FULL_NAME']}/{self.git_sha}/.build-config.yml").text
+                config = requests.get(
+                    f"https://raw.githubusercontent.com/{os.environ['REPO_FULL_NAME']}/{self.git_sha}/.build-config.yml").text
                 self._tc_config = yaml.load(config, Loader=yaml.FullLoader)
             except yaml.YAMLError:
                 raise
@@ -132,6 +133,7 @@ class Config:
         print(f"Config: {self._tc_config}")
 
         return self._tc_config
+
 
 class Shared:
     """
@@ -289,7 +291,8 @@ class Task:
         """
         for path in paths:
             if (type, path) in self.artifacts:
-                raise ValueError("Duplicate artifact: " + path)  # pragma: no cover
+                raise ValueError("Duplicate artifact: " +
+                                 path)  # pragma: no cover
             self.artifacts.append((type, path))
         return self
 
@@ -493,7 +496,8 @@ class Task:
         if gha.git_fetch_url and gha.git_fetch_url not in self.action_paths:
             self.with_additional_repo(
                 gha.git_fetch_url,
-                os.path.join(SHARED.task_root_for(self.platform()), gha.repo_name),
+                os.path.join(SHARED.task_root_for(
+                    self.platform()), gha.repo_name),
             )
             self.action_paths.add(gha.git_fetch_url)
 
@@ -709,8 +713,10 @@ class WindowsGenericWorkerTask(GenericWorkerTask):
         )
 
     def build_worker_payload(self):
-        self.scopes.append("generic-worker:os-group:divvun/windows/Administrators")
-        self.scopes.append("generic-worker:run-as-administrator:divvun/windows")
+        self.scopes.append(
+            "generic-worker:os-group:divvun/windows/Administrators")
+        self.scopes.append(
+            "generic-worker:run-as-administrator:divvun/windows")
         self.with_features("runAsAdministrator")
         return dict_update_if_truthy(
             super().build_worker_payload(),
@@ -930,7 +936,8 @@ class MacOsGenericWorkerTask(UnixTaskMixin, GenericWorkerTask):
                 "-o",
                 "pipefail",
                 "-c",
-                "{}".format(deindent("\n".join(self.scripts + self.late_scripts))),
+                "{}".format(
+                    deindent("\n".join(self.scripts + self.late_scripts))),
             ]
         ]
 
@@ -1035,7 +1042,8 @@ class DockerWorkerTask(UnixTaskMixin, Task):
                 "-o",
                 "pipefail",
                 "-c",
-                "{}".format(deindent("\n".join(self.scripts + self.late_scripts))),
+                "{}".format(
+                    deindent("\n".join(self.scripts + self.late_scripts))),
             ],
         }
         return dict_update_if_truthy(
@@ -1128,7 +1136,8 @@ def make_repo_bundle(path: str, bundle_name: str, sha: str, *, shallow=True):
     os.chdir(path)
     if shallow:
         subprocess.check_call(["git", "config", "user.name", "Decision task"])
-        subprocess.check_call(["git", "config", "user.email", "nobody@divvun.no"])
+        subprocess.check_call(
+            ["git", "config", "user.email", "nobody@divvun.no"])
         tree = subprocess.check_output(
             ["git", "show", sha, "--pretty=%T", "--no-patch"]
         )
@@ -1150,7 +1159,8 @@ def make_repo_bundle(path: str, bundle_name: str, sha: str, *, shallow=True):
         ]
     else:
         subprocess.check_call(["git", "fetch", "--unshallow", CONFIG.git_url])
-        subprocess.check_call(["git", "update-ref", CONFIG.git_bundle_shallow_ref, sha])
+        subprocess.check_call(
+            ["git", "update-ref", CONFIG.git_bundle_shallow_ref, sha])
         create = ["git", "bundle", "create", f"../{bundle_name}", "--all"]
 
     with subprocess.Popen(create) as p:

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -207,6 +207,7 @@ class Task:
         self.expires_in = "1 year"
         self.index_and_artifacts_expire_in = self.expires_in
         self.dependencies: List[str] = []
+        self.requires: List[str] = []
         self.scopes: List[str] = []
         self.routes: List[str] = []
         self.extra: Dict[str, Dict[str, str]] = {}

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -209,7 +209,6 @@ class Task:
         self.expires_in = "1 year"
         self.index_and_artifacts_expire_in = self.expires_in
         self.dependencies: List[str] = []
-        self.requires: List[str] = []
         self.scopes: List[str] = []
         self.routes: List[str] = []
         self.extra: Dict[str, Dict[str, str]] = {}
@@ -239,7 +238,6 @@ class Task:
     with_priority = chaining(setattr, "priority")
 
     with_dependencies = chaining(append_to_attr, "dependencies")
-    with_requires = chaining(append_to_attr, "requires")
     with_routes = chaining(append_to_attr, "routes")
 
     with_extra = chaining(update_attr, "extra")

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -236,6 +236,7 @@ class Task:
     with_priority = chaining(setattr, "priority")
 
     with_dependencies = chaining(append_to_attr, "dependencies")
+    with_requires = chaining(append_to_attr, "requires")
     with_routes = chaining(append_to_attr, "routes")
 
     with_extra = chaining(update_attr, "extra")

--- a/tasks/common.py
+++ b/tasks/common.py
@@ -24,7 +24,7 @@ def linux_build_task(name, bundle_dest="repo", with_secrets=True, clone_self=Tru
         decisionlib.DockerWorkerTask(name)
         .with_worker_type("linux")
         .with_provisioner_id("divvun")
-        .with_docker_image("ubuntu:22.04")
+        .with_docker_image("steffenernst/divvun-builder:latest")
         # https://docs.taskcluster.net/docs/reference/workers/docker-worker/docs/caches
         .with_scopes("docker-worker:cache:divvun-*")
         .with_scopes("queue:get-artifact:private/*")
@@ -43,11 +43,11 @@ def linux_build_task(name, bundle_dest="repo", with_secrets=True, clone_self=Tru
         .with_max_run_time_minutes(60)
         .with_script("mkdir -p $HOME/tasks/$TASK_ID")
         .with_script("mkdir -p $HOME/tasks/$TASK_ID/_temp")
-        .with_apt_update()
-        .with_apt_install("curl", "git", "python3", "python3-pip", "lsb-release")
-        .with_pip_install("taskcluster", "pyYAML")
-        .with_apt_install("wget", "nodejs", "awscli")
-        .with_apt_install("pkg-config", "libssl-dev")
+        # .with_apt_update()
+        # .with_apt_install("curl", "git", "python3", "python3-pip", "lsb-release")
+        # .with_pip_install("taskcluster", "pyYAML")
+        # .with_apt_install("wget", "nodejs", "awscli")
+        # .with_apt_install("pkg-config", "libssl-dev")
         .with_additional_repo(
             os.environ["CI_REPO_URL"],
             "${HOME}/tasks/${TASK_ID}/ci",

--- a/tasks/common.py
+++ b/tasks/common.py
@@ -24,7 +24,7 @@ def linux_build_task(name, bundle_dest="repo", with_secrets=True, clone_self=Tru
         decisionlib.DockerWorkerTask(name)
         .with_worker_type("linux")
         .with_provisioner_id("divvun")
-        .with_docker_image("steffenernst/divvun-builder:latest")
+        .with_docker_image("ubuntu:22.04")
         # https://docs.taskcluster.net/docs/reference/workers/docker-worker/docs/caches
         .with_scopes("docker-worker:cache:divvun-*")
         .with_scopes("queue:get-artifact:private/*")
@@ -43,11 +43,11 @@ def linux_build_task(name, bundle_dest="repo", with_secrets=True, clone_self=Tru
         .with_max_run_time_minutes(60)
         .with_script("mkdir -p $HOME/tasks/$TASK_ID")
         .with_script("mkdir -p $HOME/tasks/$TASK_ID/_temp")
-        # .with_apt_update()
-        # .with_apt_install("curl", "git", "python3", "python3-pip", "lsb-release")
-        # .with_pip_install("taskcluster", "pyYAML")
-        # .with_apt_install("wget", "nodejs", "awscli")
-        # .with_apt_install("pkg-config", "libssl-dev")
+        .with_apt_update()
+        .with_apt_install("curl", "git", "python3", "python3-pip", "lsb-release")
+        .with_pip_install("taskcluster", "pyYAML")
+        .with_apt_install("wget", "nodejs", "awscli")
+        .with_apt_install("pkg-config", "libssl-dev")
         .with_additional_repo(
             os.environ["CI_REPO_URL"],
             "${HOME}/tasks/${TASK_ID}/ci",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -69,7 +69,7 @@ def create_check_analysers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
+                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
             }
         )
         .with_gha(
@@ -91,7 +91,7 @@ def create_build_spellers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
+                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
             }
         )
         .with_gha(
@@ -121,7 +121,7 @@ def create_check_spellers_task(dependent_task_id):
         .with_dependencies(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
+                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
             }
         )
         .with_gha(
@@ -143,7 +143,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
+                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
             }
         )
         .with_gha(
@@ -170,7 +170,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
+                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
             }
         )
         .with_gha(
@@ -185,7 +185,7 @@ def base_lang_task(task_name, with_apertium=False):
         linux_build_task(task_name, bundle_dest="lang")
         .with_caches(
             **{
-                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
+                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
             }
         )
         .with_additional_repo(

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -92,7 +92,7 @@ def create_build_spellers_task(dependent_task_id):
         )
         .with_named_artifacts(
             "spellers",
-            "${HOME}/tasks/${task_id}/lang/build/tools/spellcheckers/*.zhfst",
+            "${HOME}/tasks/${TASK_ID}/lang/build/tools/spellcheckers/*.zhfst",
         )
         .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suiffix}")
     )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -67,7 +67,7 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
-        .with_early_script("mv ${HOME}/tasks/{dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
+        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
@@ -85,7 +85,7 @@ def create_build_spellers_task(dependent_task_id):
         base_lang_task(task_name)
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
-        .with_early_script("mv ${HOME}/tasks/{dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
+        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "build_spellers",
             GithubAction(
@@ -112,7 +112,7 @@ def create_check_spellers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
-        .with_early_script("mv ${HOME}/tasks/{dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
+        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
         )
@@ -130,7 +130,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
-        .with_early_script("mv ${HOME}/tasks/{dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
+        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "build_grammar-checkers",
             GithubAction(
@@ -153,7 +153,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
-        .with_early_script("mv ${HOME}/tasks/{dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
+        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -40,7 +40,7 @@ def create_analysers_task(with_apertium):
         'build', {}).get('analysers', False)
     should_check_analysers = CONFIG.tc_config.get(
         'check', {}).get('analysers', False)
-    task_name = "Build analysers"
+    task_name = "Build & check analysers"
     task_suffix = "-analysers"
 
     return (
@@ -60,7 +60,7 @@ def create_spellers_task(analysers_task_id):
         'build', {}).get('spellers', False)
     should_check_spellers = CONFIG.tc_config.get(
         'check', {}).get('spellers', False)
-    task_name = "Build spellers"
+    task_name = "Build & check spellers"
     task_suiffix = "-spellers"
 
     return (
@@ -90,7 +90,7 @@ def create_grammar_checkers_task(spellers_task_id):
         'check', {}).get('grammar-checkers', False)
     should_build_grammar_checkers = CONFIG.tc_config.get(
         'build', {}).get('grammar-checkers', False)
-    task_name = "Build grammar checkers"
+    task_name = "Build & check grammar checkers"
     task_suffix = "-grammar-checkers"
 
     return (

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -16,7 +16,7 @@ INSTALL_APERTIUM_LANG = {
 def create_lang_tasks(repo_name):
     should_install_apertium = (
         repo_name.endswith("apertium")
-        or repo_name[len("lang-") :] in INSTALL_APERTIUM_LANG
+        or repo_name[len("lang-"):] in INSTALL_APERTIUM_LANG
     )
 
     lang_task_id = create_lang_task(should_install_apertium)
@@ -24,7 +24,7 @@ def create_lang_tasks(repo_name):
     literal_copy_of_create_lang_task(should_install_apertium)
 
     # index_read_only means this is a PR and shouldn't run deployment steps
-    if repo_name[len("lang-") :] in NO_DEPLOY_LANG or CONFIG.index_read_only:
+    if repo_name[len("lang-"):] in NO_DEPLOY_LANG or CONFIG.index_read_only:
         return
 
     for os_, type_ in [
@@ -36,12 +36,18 @@ def create_lang_tasks(repo_name):
 
 
 def literal_copy_of_create_lang_task(with_apertium):
-    should_build_analysers = CONFIG.tc_config.get('build', {}).get('analysers', False)
-    should_build_spellers = CONFIG.tc_config.get('build', {}).get('spellers', False)
-    should_build_grammar_checkers = CONFIG.tc_config.get('build', {}).get('grammar-checkers', False)
-    should_check_analysers = CONFIG.tc_config.get('check', {}).get('analysers', False)
-    should_check_spellers = CONFIG.tc_config.get('check', {}).get('spellers', False)
-    should_check_grammar_checkers = CONFIG.tc_config.get('check', {}).get('grammar-checkers', False)
+    should_build_analysers = CONFIG.tc_config.get(
+        'build', {}).get('analysers', False)
+    should_build_spellers = CONFIG.tc_config.get(
+        'build', {}).get('spellers', False)
+    should_build_grammar_checkers = CONFIG.tc_config.get(
+        'build', {}).get('grammar-checkers', False)
+    should_check_analysers = CONFIG.tc_config.get(
+        'check', {}).get('analysers', False)
+    should_check_spellers = CONFIG.tc_config.get(
+        'check', {}).get('spellers', False)
+    should_check_grammar_checkers = CONFIG.tc_config.get(
+        'check', {}).get('grammar-checkers', False)
 
     return (
         linux_build_task("Lang build", bundle_dest="lang")
@@ -103,12 +109,18 @@ def literal_copy_of_create_lang_task(with_apertium):
 
 
 def create_lang_task(with_apertium):
-    should_build_analysers = CONFIG.tc_config.get('build', {}).get('analysers', False)
-    should_build_spellers = CONFIG.tc_config.get('build', {}).get('spellers', False)
-    should_build_grammar_checkers = CONFIG.tc_config.get('build', {}).get('grammar-checkers', False)
-    should_check_analysers = CONFIG.tc_config.get('check', {}).get('analysers', False)
-    should_check_spellers = CONFIG.tc_config.get('check', {}).get('spellers', False)
-    should_check_grammar_checkers = CONFIG.tc_config.get('check', {}).get('grammar-checkers', False)
+    should_build_analysers = CONFIG.tc_config.get(
+        'build', {}).get('analysers', False)
+    should_build_spellers = CONFIG.tc_config.get(
+        'build', {}).get('spellers', False)
+    should_build_grammar_checkers = CONFIG.tc_config.get(
+        'build', {}).get('grammar-checkers', False)
+    should_check_analysers = CONFIG.tc_config.get(
+        'check', {}).get('analysers', False)
+    should_check_spellers = CONFIG.tc_config.get(
+        'check', {}).get('spellers', False)
+    should_check_grammar_checkers = CONFIG.tc_config.get(
+        'check', {}).get('grammar-checkers', False)
 
     return (
         linux_build_task("Lang build", bundle_dest="lang")

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -65,13 +65,13 @@ def create_spellers_task(analysers_task_id):
 
     return (
         base_lang_task(task_name)
+        .with_dependencies(analysers_task_id)
         .with_gha(
             "build_spellers",
             GithubAction(
                 "technocreatives/divvun-taskcluster-gha-test/lang/build",
                 {"fst": "hfst", "spellers": "true"}
-            )
-            .with_outputs_from(analysers_task_id),
+            ),
             enabled=should_build_spellers
         )
         .with_gha(
@@ -95,6 +95,7 @@ def create_grammar_checkers_task(spellers_task_id):
 
     return (
         base_lang_task(task_name)
+        .with_dependencies(spellers_task_id)
         .with_gha(
             "build_grammar-checkers",
             GithubAction(
@@ -103,7 +104,6 @@ def create_grammar_checkers_task(spellers_task_id):
             ),
             enabled=should_build_grammar_checkers
         )
-        .with_dependencies(spellers_task_id)
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -65,7 +65,7 @@ def create_check_analysers_task(dependent_task_id):
 
     return (
         linux_build_task(task_name, bundle_dest="lang")
-        .with_dependencies(dependent_task_id)
+        # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
@@ -82,7 +82,7 @@ def create_build_spellers_task(dependent_task_id):
 
     return (
         base_lang_task(task_name)
-        .with_dependencies(dependent_task_id)
+        # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
         .with_gha(
             "build_spellers",
@@ -108,7 +108,7 @@ def create_check_spellers_task(dependent_task_id):
 
     return (
         linux_build_task(task_name, bundle_dest="lang")
-        .with_dependencies(dependent_task_id)
+        # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
@@ -125,7 +125,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
 
     return (
         linux_build_task(task_name, bundle_dest="lang")
-        .with_dependencies(dependent_task_id)
+        # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
         .with_gha(
             "build_grammar-checkers",
@@ -147,7 +147,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
 
     return (
         linux_build_task(task_name, bundle_dest="lang")
-        .with_dependencies(dependent_task_id)
+        # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -67,7 +67,7 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}", True)
+        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
@@ -85,7 +85,7 @@ def create_build_spellers_task(dependent_task_id):
         base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}", True)
+        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "build_spellers",
             GithubAction(
@@ -112,7 +112,7 @@ def create_check_spellers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}", True)
+        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
         )
@@ -130,7 +130,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}", True)
+        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "build_grammar-checkers",
             GithubAction(
@@ -153,7 +153,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}", True)
+        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -21,7 +21,7 @@ def create_lang_tasks(repo_name):
 
     analysers_task_id = create_analysers_task(should_install_apertium)
     spellers_task_id = create_spellers_task(analysers_task_id)
-    unused_grammar_task_id = create_grammar_checkers_task(spellers_task_id)
+    create_grammar_checkers_task(spellers_task_id)
 
     # index_read_only means this is a PR and shouldn't run deployment steps
     if repo_name[len("lang-"):] in NO_DEPLOY_LANG or CONFIG.index_read_only:

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -24,6 +24,8 @@ def create_lang_tasks(repo_name):
 
     lang_task_id = create_lang_task(should_install_apertium)
 
+    create_test_task()
+
     # index_read_only means this is a PR and shouldn't run deployment steps
     if repo_name[len("lang-") :] in NO_DEPLOY_LANG or CONFIG.index_read_only:
         return
@@ -35,6 +37,17 @@ def create_lang_tasks(repo_name):
     ]:
         create_bundle_task(os_, type_, lang_task_id)
 
+def create_test_task():
+    print("RUNNING create_test_task")
+    return (
+        linux_build_task("Test speller build")
+        .with_gha(
+            "build_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "spellers": "true"})
+        )
+        .with_gha(
+            "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {})
+        )
+    )
 
 def create_lang_task(with_apertium):
     should_build_analysers = CONFIG.tc_config.get('build', {}).get('analysers', False)

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -80,7 +80,8 @@ def create_build_spellers_task(dependent_task_id):
     task_suiffix = "-spellers-build"
 
     return (
-        base_lang_task(task_name)
+        # base_lang_task(task_name)
+        linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         .with_gha(
             "build_spellers",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -44,6 +44,63 @@ def create_analysers_task(with_apertium):
     task_suffix = "-analysers"
 
     return (
+        base_lang_task(task_name, with_apertium)
+        .with_gha(
+            "build_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "analysers": "true", "spellers": "false"}), enabled=should_build_analysers
+        )
+        .with_gha(
+            "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
+        )
+        .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suffix}")
+    )
+
+
+def create_spellers_task():
+    should_build_spellers = CONFIG.tc_config.get(
+        'build', {}).get('spellers', False)
+    should_check_spellers = CONFIG.tc_config.get(
+        'check', {}).get('spellers', False)
+    task_name = "Build spellers"
+    task_suiffix = "-spellers"
+
+    return (
+        base_lang_task(task_name)
+        .with_gha(
+            "build_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "spellers": "true"}), enabled=should_build_spellers
+        )
+        .with_gha(
+            "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
+        )
+        .with_named_artifacts(
+            "spellers",
+            "${home}/tasks/${task_id}/lang/build/tools/spellcheckers/*.zhfst",
+        )
+        .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suiffix}")
+    )
+
+
+def create_grammar_checkers_task():
+    should_check_grammar_checkers = CONFIG.tc_config.get(
+        'check', {}).get('grammar-checkers', False)
+    should_build_grammar_checkers = CONFIG.tc_config.get(
+        'build', {}).get('grammar-checkers', False)
+    task_name = "Build grammar checkers"
+    task_suffix = "-grammar-checkers"
+
+    return (
+        base_lang_task(task_name)
+        .with_gha(
+            "build_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "grammar-checkers": "true"}), enabled=should_build_grammar_checkers
+        )
+        .with_gha(
+            "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
+        )
+        .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suffix}")
+    )
+
+
+def base_lang_task(task_name, with_apertium=False):
+    return (
         linux_build_task(task_name, bundle_dest="lang")
         .with_additional_repo(
             "https://github.com/giellalt/giella-core.git",
@@ -76,57 +133,6 @@ def create_analysers_task(with_apertium):
                 {"sudo": "false", "apertium": with_apertium},
             ),
         )
-        .with_gha(
-            "build_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "analysers": "true", "spellers": "false"}), enabled=should_build_analysers
-        )
-        .with_gha(
-            "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
-        )
-        .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suffix}")
-    )
-
-
-def create_spellers_task():
-    should_build_spellers = CONFIG.tc_config.get(
-        'build', {}).get('spellers', False)
-    should_check_spellers = CONFIG.tc_config.get(
-        'check', {}).get('spellers', False)
-    task_name = "Build spellers"
-    task_suiffix = "-spellers"
-
-    return (
-        linux_build_task(task_name, bundle_dest="lang")
-        .with_gha(
-            "build_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "spellers": "true"}), enabled=should_build_spellers
-        )
-        .with_gha(
-            "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
-        )
-        .with_named_artifacts(
-            "spellers",
-            "${home}/tasks/${task_id}/lang/build/tools/spellcheckers/*.zhfst",
-        )
-        .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suiffix}")
-    )
-
-
-def create_grammar_checkers_task():
-    should_check_grammar_checkers = CONFIG.tc_config.get(
-        'check', {}).get('grammar-checkers', False)
-    should_build_grammar_checkers = CONFIG.tc_config.get(
-        'build', {}).get('grammar-checkers', False)
-    task_name = "Build grammar checkers"
-    task_suffix = "-grammar-checkers"
-
-    return (
-        linux_build_task(task_name, bundle_dest="lang")
-        .with_gha(
-            "build_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "grammar-checkers": "true"}), enabled=should_build_grammar_checkers
-        )
-        .with_gha(
-            "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
-        )
-        .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suffix}")
     )
 
 

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -1,4 +1,4 @@
-from gha import GithubAction
+from gha import GithubAction, GithubActionScript
 from decisionlib import CONFIG
 from .common import linux_build_task, macos_task, windows_task, NIGHTLY_CHANNEL, gha_setup
 
@@ -67,7 +67,12 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script("mv $HOME/tasks/%s/* $HOME/tasks/$TASK_ID" % dependent_task_id)
+        .with_gha(
+            "copy dependent task build folder",
+            GithubActionScript(
+                f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}"
+            ),
+        )
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -6,7 +6,7 @@ from decisionlib import CONFIG
 from .common import linux_build_task, macos_task, windows_task, NIGHTLY_CHANNEL, gha_setup
 
 NO_DEPLOY_LANG = {
-    "zxx",  # No linguistic data
+    # "zxx",  # No linguistic data
     "est-x-plamk",
     "nno-x-ext-apertium",
 }

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -21,7 +21,7 @@ def create_lang_tasks(repo_name):
 
     lang_task_id = create_lang_task(should_install_apertium)
 
-    literal_copy_of_create_lang_task(should_install_apertium)
+    lang_task_id_2 = literal_copy_of_create_lang_task(should_install_apertium)
 
     # index_read_only means this is a PR and shouldn't run deployment steps
     if repo_name[len("lang-"):] in NO_DEPLOY_LANG or CONFIG.index_read_only:
@@ -50,7 +50,7 @@ def literal_copy_of_create_lang_task(with_apertium):
         'check', {}).get('grammar-checkers', False)
 
     return (
-        linux_build_task("Lang build", bundle_dest="lang")
+        linux_build_task("Lang build TEST", bundle_dest="lang")
         .with_additional_repo(
             "https://github.com/giellalt/giella-core.git",
             "${HOME}/tasks/${TASK_ID}/giella-core",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -49,8 +49,7 @@ def create_build_analysers_task(with_apertium):
     task_suffix = "-analysers-build"
 
     return (
-        # TODO: Test
-        linux_build_task(task_name, bundle_dest="lang")
+        base_lang_task(task_name, with_apertium)
         .with_gha(
             "build_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "analysers": "true", "spellers": "false"}), enabled=should_build_analysers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -67,7 +67,7 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/* $HOME/tasks/$TASK_ID")
+        .with_early_script("mv '$HOME/tasks/"+dependent_task_id+"/*' $HOME/tasks/$TASK_ID")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -100,16 +100,11 @@ def create_grammar_checkers_task(spellers_task_id):
             GithubAction(
                 "technocreatives/divvun-taskcluster-gha-test/lang/build",
                 {"fst": "hfst", "grammar-checkers": "true"}
-            )
-            .with_outputs_from(spellers_task_id),
+            ).with_outputs_from(spellers_task_id),
             enabled=should_build_grammar_checkers
         )
         .with_gha(
-            "check_grammar-checkers",
-            GithubAction(
-                "technocreatives/divvun-taskcluster-gha-test/lang/check", {}
-            ).with_outputs_from(spellers_task_id),
-            enabled=should_check_grammar_checkers
+            "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )
         .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suffix}")
     )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -69,7 +69,7 @@ def create_check_analysers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
+                "divvun-lang-task-cache": "/root/tasks/${TASK_ID}",
             }
         )
         .with_gha(
@@ -91,7 +91,7 @@ def create_build_spellers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
+                "divvun-lang-task-cache": "/root/tasks/${TASK_ID}",
             }
         )
         .with_gha(
@@ -121,7 +121,7 @@ def create_check_spellers_task(dependent_task_id):
         .with_dependencies(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
+                "divvun-lang-task-cache": "/root/tasks/${TASK_ID}",
             }
         )
         .with_gha(
@@ -143,7 +143,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
+                "divvun-lang-task-cache": "/root/tasks/${TASK_ID}",
             }
         )
         .with_gha(
@@ -170,7 +170,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
+                "divvun-lang-task-cache": "/root/tasks/${TASK_ID}",
             }
         )
         .with_gha(
@@ -185,7 +185,7 @@ def base_lang_task(task_name, with_apertium=False):
         linux_build_task(task_name, bundle_dest="lang")
         .with_caches(
             **{
-                "divvun-lang-task-cache": "${HOME}/tasks/${TASK_ID}",
+                "divvun-lang-task-cache": "/root/tasks/${TASK_ID}",
             }
         )
         .with_additional_repo(

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -49,7 +49,8 @@ def create_build_analysers_task(with_apertium):
     task_suffix = "-analysers-build"
 
     return (
-        base_lang_task(task_name, with_apertium)
+        # TODO: Test
+        linux_build_task(task_name, bundle_dest="lang")
         .with_gha(
             "build_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/build", {"fst": "hfst", "analysers": "true", "spellers": "false"}), enabled=should_build_analysers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -100,11 +100,16 @@ def create_grammar_checkers_task(spellers_task_id):
             GithubAction(
                 "technocreatives/divvun-taskcluster-gha-test/lang/build",
                 {"fst": "hfst", "grammar-checkers": "true"}
-            ).with_outputs_from(spellers_task_id),
+            )
+            .with_outputs_from(spellers_task_id),
             enabled=should_build_grammar_checkers
         )
         .with_gha(
-            "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
+            "check_grammar-checkers",
+            GithubAction(
+                "technocreatives/divvun-taskcluster-gha-test/lang/check", {}
+            ).with_outputs_from(spellers_task_id),
+            enabled=should_check_grammar_checkers
         )
         .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suffix}")
     )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -80,7 +80,7 @@ def create_build_spellers_task(dependent_task_id):
     task_suiffix = "-spellers-build"
 
     return (
-        linux_build_task(task_name, bundle_dest="lang")
+        base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
         .with_gha(
             "build_spellers",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -70,6 +70,9 @@ def create_check_analysers_task(dependent_task_id):
         .with_caches(
             **{
                 "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+                "divvun-cargo-registry": "/root/.cargo/registry",
+                "divvun-cargo-git": "/root/.cargo/git",
+                "divvun-rustup": "/root/.rustup",
             }
         )
         .with_gha(
@@ -89,7 +92,6 @@ def create_build_spellers_task(dependent_task_id):
         base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_caches()
         .with_gha(
             "build_spellers",
             GithubAction(
@@ -118,6 +120,9 @@ def create_check_spellers_task(dependent_task_id):
         .with_caches(
             **{
                 "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+                "divvun-cargo-registry": "/root/.cargo/registry",
+                "divvun-cargo-git": "/root/.cargo/git",
+                "divvun-rustup": "/root/.rustup",
             }
         )
         .with_gha(
@@ -140,6 +145,9 @@ def create_build_grammar_checkers_task(dependent_task_id):
         .with_caches(
             **{
                 "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+                "divvun-cargo-registry": "/root/.cargo/registry",
+                "divvun-cargo-git": "/root/.cargo/git",
+                "divvun-rustup": "/root/.rustup",
             }
         )
         .with_gha(
@@ -167,6 +175,9 @@ def create_check_grammar_checkers_task(dependent_task_id):
         .with_caches(
             **{
                 "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+                "divvun-cargo-registry": "/root/.cargo/registry",
+                "divvun-cargo-git": "/root/.cargo/git",
+                "divvun-rustup": "/root/.rustup",
             }
         )
         .with_gha(
@@ -182,6 +193,9 @@ def base_lang_task(task_name, with_apertium=False):
         .with_caches(
             **{
                 "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+                "divvun-cargo-registry": "/root/.cargo/registry",
+                "divvun-cargo-git": "/root/.cargo/git",
+                "divvun-rustup": "/root/.rustup",
             }
         )
         .with_additional_repo(

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -69,10 +69,7 @@ def create_check_analysers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
-                "divvun-cargo-registry": "/root/.cargo/registry",
-                "divvun-cargo-git": "/root/.cargo/git",
-                "divvun-rustup": "/root/.rustup",
+                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
             }
         )
         .with_gha(
@@ -92,6 +89,11 @@ def create_build_spellers_task(dependent_task_id):
         base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
+        .with_caches(
+            **{
+                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
+            }
+        )
         .with_gha(
             "build_spellers",
             GithubAction(
@@ -119,10 +121,7 @@ def create_check_spellers_task(dependent_task_id):
         .with_dependencies(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
-                "divvun-cargo-registry": "/root/.cargo/registry",
-                "divvun-cargo-git": "/root/.cargo/git",
-                "divvun-rustup": "/root/.rustup",
+                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
             }
         )
         .with_gha(
@@ -144,10 +143,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
-                "divvun-cargo-registry": "/root/.cargo/registry",
-                "divvun-cargo-git": "/root/.cargo/git",
-                "divvun-rustup": "/root/.rustup",
+                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
             }
         )
         .with_gha(
@@ -174,10 +170,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
-                "divvun-cargo-registry": "/root/.cargo/registry",
-                "divvun-cargo-git": "/root/.cargo/git",
-                "divvun-rustup": "/root/.rustup",
+                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
             }
         )
         .with_gha(
@@ -192,10 +185,7 @@ def base_lang_task(task_name, with_apertium=False):
         linux_build_task(task_name, bundle_dest="lang")
         .with_caches(
             **{
-                "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
-                "divvun-cargo-registry": "/root/.cargo/registry",
-                "divvun-cargo-git": "/root/.cargo/git",
-                "divvun-rustup": "/root/.rustup",
+                "divvun-lang-task-cache": "$HOME/tasks/$TASK_ID",
             }
         )
         .with_additional_repo(

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -67,7 +67,7 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
+        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/* $HOME/tasks/$TASK_ID")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
@@ -85,7 +85,7 @@ def create_build_spellers_task(dependent_task_id):
         base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
+        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/* $HOME/tasks/$TASK_ID")
         .with_gha(
             "build_spellers",
             GithubAction(
@@ -112,7 +112,7 @@ def create_check_spellers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
+        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/* $HOME/tasks/$TASK_ID")
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
         )
@@ -130,7 +130,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
+        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/* $HOME/tasks/$TASK_ID")
         .with_gha(
             "build_grammar-checkers",
             GithubAction(
@@ -153,7 +153,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
+        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/* $HOME/tasks/$TASK_ID")
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -67,7 +67,7 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/lalala $HOME/tasks/$TASK_ID")
+        .with_early_script("mv $HOME/tasks/%s/* $HOME/tasks/$TASK_ID" % dependent_task_id)
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
@@ -397,3 +397,4 @@ def create_bundle_task(os_name, type_, lang_task_id):
         )
 
     raise NotImplementedError
+

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -69,7 +69,7 @@ def create_check_analysers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         # .with_early_script("mv $HOME/tasks/%s/* $HOME/tasks/$TASK_ID" % dependent_task_id)
         # .with_early_script("cd $HOME/tasks/{dependent_task_id}/; for file in `ls`; mv $file $HOME/tasks/$TASK_ID")
-        .with_early_script("for file in `ls $HOME/tasks/{dependent_task_id}` && mv $HOME/tasks/{dependent_task_id}/$file $HOME/tasks/$TASK_ID")
+        .with_early_script(f"ls $HOME/tasks/{dependent_task_id}")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
@@ -399,3 +399,4 @@ def create_bundle_task(os_name, type_, lang_task_id):
         )
 
     raise NotImplementedError
+

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -76,6 +76,7 @@ def create_test_task(with_apertium):
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {})
         )
+        .find_or_create(f"build.linux_x64.{CONFIG.index_path}")
     )
 
 

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -93,7 +93,6 @@ def create_spellers_task(dependent_task_id):
     return (
         base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
-        # .with_requires(dependent_task_id)
         .with_gha(
             "build_spellers",
             GithubAction(
@@ -126,7 +125,6 @@ def create_grammar_checkers_task(dependent_task_id):
     return (
         base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
-        # .with_requires(dependent_task_id)
         .with_gha(
             "build_grammar-checkers",
             GithubAction(

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -19,8 +19,8 @@ def create_lang_tasks(repo_name):
         or repo_name[len("lang-"):] in INSTALL_APERTIUM_LANG
     )
 
-    create_analysers_task()
-    spellers_task_id = create_spellers_task(should_install_apertium)
+    create_analysers_task(should_install_apertium)
+    spellers_task_id = create_spellers_task()
     create_grammar_checkers_task()
 
     # index_read_only means this is a PR and shouldn't run deployment steps

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -65,8 +65,8 @@ def create_check_analysers_task(dependent_task_id):
 
     return (
         linux_build_task(task_name, bundle_dest="lang")
-        # .with_dependencies(dependent_task_id)
-        .with_requires(dependent_task_id)
+        .with_dependencies(dependent_task_id)
+        # .with_requires(dependent_task_id)
         .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
@@ -83,8 +83,8 @@ def create_build_spellers_task(dependent_task_id):
 
     return (
         base_lang_task(task_name)
-        # .with_dependencies(dependent_task_id)
-        .with_requires(dependent_task_id)
+        .with_dependencies(dependent_task_id)
+        # .with_requires(dependent_task_id)
         .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "build_spellers",
@@ -110,8 +110,8 @@ def create_check_spellers_task(dependent_task_id):
 
     return (
         linux_build_task(task_name, bundle_dest="lang")
-        # .with_dependencies(dependent_task_id)
-        .with_requires(dependent_task_id)
+        .with_dependencies(dependent_task_id)
+        # .with_requires(dependent_task_id)
         .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
@@ -128,8 +128,8 @@ def create_build_grammar_checkers_task(dependent_task_id):
 
     return (
         linux_build_task(task_name, bundle_dest="lang")
-        # .with_dependencies(dependent_task_id)
-        .with_requires(dependent_task_id)
+        .with_dependencies(dependent_task_id)
+        # .with_requires(dependent_task_id)
         .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "build_grammar-checkers",
@@ -151,8 +151,8 @@ def create_check_grammar_checkers_task(dependent_task_id):
 
     return (
         linux_build_task(task_name, bundle_dest="lang")
-        # .with_dependencies(dependent_task_id)
-        .with_requires(dependent_task_id)
+        .with_dependencies(dependent_task_id)
+        # .with_requires(dependent_task_id)
         .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -100,7 +100,8 @@ def create_grammar_checkers_task(spellers_task_id):
             GithubAction(
                 "technocreatives/divvun-taskcluster-gha-test/lang/build",
                 {"fst": "hfst", "grammar-checkers": "true"}
-            ).with_outputs_from(spellers_task_id),
+            )
+            .with_dependencies(spellers_task_id),
             enabled=should_build_grammar_checkers
         )
         .with_gha(

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -67,7 +67,7 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
+        .with_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}", True)
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
@@ -85,7 +85,7 @@ def create_build_spellers_task(dependent_task_id):
         base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
+        .with_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}", True)
         .with_gha(
             "build_spellers",
             GithubAction(
@@ -112,7 +112,7 @@ def create_check_spellers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
+        .with_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}", True)
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
         )
@@ -130,7 +130,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
+        .with_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}", True)
         .with_gha(
             "build_grammar-checkers",
             GithubAction(
@@ -153,7 +153,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}")
+        .with_script(f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}", True)
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -67,6 +67,7 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
+        .with_script("mv ${HOME}/tasks/${dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
@@ -84,6 +85,7 @@ def create_build_spellers_task(dependent_task_id):
         base_lang_task(task_name)
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
+        .with_script("mv ${HOME}/tasks/${dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
         .with_gha(
             "build_spellers",
             GithubAction(
@@ -110,6 +112,7 @@ def create_check_spellers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
+        .with_script("mv ${HOME}/tasks/${dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
         )
@@ -127,6 +130,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
+        .with_script("mv ${HOME}/tasks/${dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
         .with_gha(
             "build_grammar-checkers",
             GithubAction(
@@ -149,6 +153,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
+        .with_script("mv ${HOME}/tasks/${dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -124,7 +124,7 @@ def create_grammar_checkers_task(dependent_task_id):
     task_suffix = "-grammar-checkers"
 
     return (
-        linux_build_task(task_name, bundle_dest="lang")
+        base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
         .with_gha(

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -100,10 +100,10 @@ def create_grammar_checkers_task(spellers_task_id):
             GithubAction(
                 "technocreatives/divvun-taskcluster-gha-test/lang/build",
                 {"fst": "hfst", "grammar-checkers": "true"}
-            )
-            .with_dependencies(spellers_task_id),
+            ),
             enabled=should_build_grammar_checkers
         )
+        .with_dependencies(spellers_task_id)
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -3,7 +3,7 @@ from decisionlib import CONFIG
 from .common import linux_build_task, macos_task, windows_task, NIGHTLY_CHANNEL, gha_setup
 
 NO_DEPLOY_LANG = {
-    # "zxx",  # No linguistic data
+    "zxx",  # No linguistic data
     "est-x-plamk",
     "nno-x-ext-apertium",
 }

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -66,6 +66,7 @@ def create_check_analysers_task(dependent_task_id):
     return (
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
+        .with_requires(dependent_task_id)
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
@@ -82,6 +83,7 @@ def create_build_spellers_task(dependent_task_id):
     return (
         base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
+        .with_requires(dependent_task_id)
         .with_gha(
             "build_spellers",
             GithubAction(
@@ -107,6 +109,7 @@ def create_check_spellers_task(dependent_task_id):
     return (
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
+        .with_requires(dependent_task_id)
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
         )
@@ -123,6 +126,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
     return (
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
+        .with_requires(dependent_task_id)
         .with_gha(
             "build_grammar-checkers",
             GithubAction(
@@ -144,6 +148,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
     return (
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
+        .with_requires(dependent_task_id)
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -64,7 +64,8 @@ def create_check_analysers_task(dependent_task_id):
     task_suffix = "-analysers-check"
 
     return (
-        base_lang_task(task_name)
+        # TODO: this be a test
+        linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -69,7 +69,7 @@ def create_check_analysers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "lang_task_cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+                "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
             }
         )
         .with_gha(
@@ -117,7 +117,7 @@ def create_check_spellers_task(dependent_task_id):
         .with_dependencies(dependent_task_id)
         .with_caches(
             **{
-                "lang_task_cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+                "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
             }
         )
         .with_gha(
@@ -139,7 +139,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "lang_task_cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+                "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
             }
         )
         .with_gha(
@@ -166,7 +166,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         .with_caches(
             **{
-                "lang_task_cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+                "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
             }
         )
         .with_gha(
@@ -181,7 +181,7 @@ def base_lang_task(task_name, with_apertium=False):
         linux_build_task(task_name, bundle_dest="lang")
         .with_caches(
             **{
-                "lang_task_cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+                "divvun-lang-task-cache": f"${{HOME}}/tasks/${{TASK_ID}}",
             }
         )
         .with_additional_repo(

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -21,7 +21,7 @@ def create_lang_tasks(repo_name):
 
     analysers_task_id = create_analysers_task(should_install_apertium)
     spellers_task_id = create_spellers_task(analysers_task_id)
-    create_grammar_checkers_task(spellers_task_id)
+    unused_grammar_task_id = create_grammar_checkers_task(spellers_task_id)
 
     # index_read_only means this is a PR and shouldn't run deployment steps
     if repo_name[len("lang-"):] in NO_DEPLOY_LANG or CONFIG.index_read_only:

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -64,7 +64,6 @@ def create_check_analysers_task(dependent_task_id):
     task_suffix = "-analysers-check"
 
     return (
-        # TODO: this be a test
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         .with_gha(
@@ -81,7 +80,7 @@ def create_build_spellers_task(dependent_task_id):
     task_suiffix = "-spellers-build"
 
     return (
-        base_lang_task(task_name)
+        linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         .with_gha(
             "build_spellers",
@@ -106,7 +105,7 @@ def create_check_spellers_task(dependent_task_id):
     task_suiffix = "-spellers-check"
 
     return (
-        base_lang_task(task_name)
+        linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
@@ -122,7 +121,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
     task_suffix = "-grammar-checkers-build"
 
     return (
-        base_lang_task(task_name)
+        linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         .with_gha(
             "build_grammar-checkers",
@@ -143,7 +142,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
     task_suffix = "-grammar-checkers-check"
 
     return (
-        base_lang_task(task_name)
+        linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -92,7 +92,7 @@ def create_build_spellers_task(dependent_task_id):
         )
         .with_named_artifacts(
             "spellers",
-            "${home}/tasks/${task_id}/lang/build/tools/spellcheckers/*.zhfst",
+            "${HOME}/tasks/${task_id}/lang/build/tools/spellcheckers/*.zhfst",
         )
         .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suiffix}")
     )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -69,7 +69,7 @@ def create_check_analysers_task(dependent_task_id):
         # .with_requires(dependent_task_id)
         # .with_early_script("mv $HOME/tasks/%s/* $HOME/tasks/$TASK_ID" % dependent_task_id)
         # .with_early_script("cd $HOME/tasks/{dependent_task_id}/; for file in `ls`; mv $file $HOME/tasks/$TASK_ID")
-        .with_early_script("for file in `ls $HOME/tasks/{dependent_task_id}`; mv $HOME/tasks/{dependent_task_id}/$file $HOME/tasks/$TASK_ID")
+        .with_early_script("for file in `ls $HOME/tasks/{dependent_task_id}` && mv $HOME/tasks/{dependent_task_id}/$file $HOME/tasks/$TASK_ID")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -38,7 +38,7 @@ def create_lang_tasks(repo_name):
 def create_test_task(with_apertium):
     print("RUNNING create_test_task")
     return (
-        linux_build_task("Test speller build")
+        linux_build_task("Test speller build", bundle_dest="lang")
         .with_additional_repo(
             "https://github.com/giellalt/giella-core.git",
             "${HOME}/tasks/${TASK_ID}/giella-core",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -67,7 +67,7 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
-        .with_script("mv ${HOME}/tasks/${dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
+        .with_early_script("mv ${HOME}/tasks/{dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
@@ -85,7 +85,7 @@ def create_build_spellers_task(dependent_task_id):
         base_lang_task(task_name)
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
-        .with_script("mv ${HOME}/tasks/${dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
+        .with_early_script("mv ${HOME}/tasks/{dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
         .with_gha(
             "build_spellers",
             GithubAction(
@@ -112,7 +112,7 @@ def create_check_spellers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
-        .with_script("mv ${HOME}/tasks/${dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
+        .with_early_script("mv ${HOME}/tasks/{dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
         )
@@ -130,7 +130,7 @@ def create_build_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
-        .with_script("mv ${HOME}/tasks/${dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
+        .with_early_script("mv ${HOME}/tasks/{dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
         .with_gha(
             "build_grammar-checkers",
             GithubAction(
@@ -153,7 +153,7 @@ def create_check_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         # .with_dependencies(dependent_task_id)
         .with_requires(dependent_task_id)
-        .with_script("mv ${HOME}/tasks/${dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
+        .with_early_script("mv ${HOME}/tasks/{dependent_task_id}/* ${HOME}/tasks/${TASK_ID}")
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -63,7 +63,7 @@ def create_analysers_task(with_apertium):
         .with_gha(
             "build_analysers",
             GithubAction(
-                "technocreatives/divvun-taskcluster-gha-test/lang/build",
+                "divvun/taskcluster-gha/lang/build",
                 {
                     "fst": "hfst",
                     "analysers": "true",
@@ -74,7 +74,7 @@ def create_analysers_task(with_apertium):
         .with_gha(
             "check_analysers",
             GithubAction(
-                "technocreatives/divvun-taskcluster-gha-test/lang/check", {}
+                "divvun/taskcluster-gha/lang/check", {}
             ), enabled=should_check_analysers
         )
         .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suffix}")
@@ -97,13 +97,13 @@ def create_spellers_task(dependent_task_id):
         .with_gha(
             "build_spellers",
             GithubAction(
-                "technocreatives/divvun-taskcluster-gha-test/lang/build",
+                "divvun/taskcluster-gha/lang/build",
                 {"fst": "hfst", "spellers": "true"}
             )
         )
         .with_gha(
             "check_spellers", GithubAction(
-                "technocreatives/divvun-taskcluster-gha-test/lang/check", {}
+                "divvun/taskcluster-gha/lang/check", {}
             ), enabled=should_check_spellers
         )
         .with_named_artifacts(
@@ -130,14 +130,14 @@ def create_grammar_checkers_task(dependent_task_id):
         .with_gha(
             "build_grammar-checkers",
             GithubAction(
-                "technocreatives/divvun-taskcluster-gha-test/lang/build",
+                "divvun/taskcluster-gha/lang/build",
                 {"fst": "hfst", "grammar-checkers": "true"}
             )
         )
         .with_gha(
             "check_grammar-checkers",
             GithubAction(
-                "technocreatives/divvun-taskcluster-gha-test/lang/check", {}
+                "divvun/taskcluster-gha/lang/check", {}
             ), enabled=should_check_grammar_checkers
         )
         .find_or_create(f"build.linux_x64.{CONFIG.index_path}{task_suffix}")
@@ -174,7 +174,7 @@ def base_lang_task(task_name, with_apertium=False):
         .with_gha(
             "deps",
             GithubAction(
-                "technocreatives/divvun-taskcluster-gha-test/lang/install-deps",
+                "divvun/taskcluster-gha/lang/install-deps",
                 {"sudo": "false", "apertium": with_apertium},
             ),
         )
@@ -192,7 +192,7 @@ def create_bundle_task(os_name, type_, lang_task_id):
             .with_gha(
                 "init",
                 GithubAction(
-                    "technocreatives/divvun-taskcluster-gha-test/pahkat/init",
+                    "divvun/taskcluster-gha/pahkat/init",
                     {
                         "repo": "https://pahkat.uit.no/devtools/",
                         "channel": NIGHTLY_CHANNEL,
@@ -204,7 +204,7 @@ def create_bundle_task(os_name, type_, lang_task_id):
             .with_gha(
                 "version",
                 GithubAction(
-                    "technocreatives/divvun-taskcluster-gha-test/version",
+                    "divvun/taskcluster-gha/version",
                     {
                         "speller-manifest": True,
                         "nightly-channel": NIGHTLY_CHANNEL,
@@ -215,7 +215,7 @@ def create_bundle_task(os_name, type_, lang_task_id):
             .with_gha(
                 "bundler",
                 GithubAction(
-                    "technocreatives/divvun-taskcluster-gha-test/speller/bundle",
+                    "divvun/taskcluster-gha/speller/bundle",
                     {
                         "speller-type": type_,
                         "speller-manifest-path": "manifest.toml",
@@ -227,7 +227,7 @@ def create_bundle_task(os_name, type_, lang_task_id):
             .with_gha(
                 "deploy",
                 GithubAction(
-                    "technocreatives/divvun-taskcluster-gha-test/speller/deploy",
+                    "divvun/taskcluster-gha/speller/deploy",
                     {
                         "speller-type": type_,
                         "speller-manifest-path": "manifest.toml",
@@ -251,7 +251,7 @@ def create_bundle_task(os_name, type_, lang_task_id):
             .with_gha(
                 "init",
                 GithubAction(
-                    "technocreatives/divvun-taskcluster-gha-test/pahkat/init",
+                    "divvun/taskcluster-gha/pahkat/init",
                     {
                         "repo": "https://pahkat.uit.no/devtools/",
                         "channel": NIGHTLY_CHANNEL,
@@ -262,7 +262,7 @@ def create_bundle_task(os_name, type_, lang_task_id):
             .with_gha(
                 "setup",
                 GithubAction(
-                    "technocreatives/divvun-taskcluster-gha-test/setup", {}
+                    "divvun/taskcluster-gha/setup", {}
                 ).with_secret_input(
                     "key", "divvun", "DIVVUN_KEY"
                 ),
@@ -270,7 +270,7 @@ def create_bundle_task(os_name, type_, lang_task_id):
             .with_gha(
                 "version",
                 GithubAction(
-                    "technocreatives/divvun-taskcluster-gha-test/version",
+                    "divvun/taskcluster-gha/version",
                     {
                         "speller-manifest": True,
                         "nightly-channel": NIGHTLY_CHANNEL,
@@ -281,7 +281,7 @@ def create_bundle_task(os_name, type_, lang_task_id):
             .with_gha(
                 "bundler",
                 GithubAction(
-                    "technocreatives/divvun-taskcluster-gha-test/speller/bundle",
+                    "divvun/taskcluster-gha/speller/bundle",
                     {
                         "speller-type": type_,
                         "speller-manifest-path": "manifest.toml",
@@ -293,7 +293,7 @@ def create_bundle_task(os_name, type_, lang_task_id):
             .with_gha(
                 "deploy",
                 GithubAction(
-                    "technocreatives/divvun-taskcluster-gha-test/speller/deploy",
+                    "divvun/taskcluster-gha/speller/deploy",
                     {
                         "speller-type": type_,
                         "speller-manifest-path": "manifest.toml",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -104,7 +104,7 @@ def literal_copy_of_create_lang_task(with_apertium):
             "spellers",
             "${HOME}/tasks/${TASK_ID}/lang/build/tools/spellcheckers/*.zhfst",
         )
-        .find_or_create(f"build.linux_x64.{CONFIG.index_path}")
+        .find_or_create(f"build.linux_x64.{CONFIG.index_path}-test")
     )
 
 

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -67,7 +67,7 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script("mv '$HOME/tasks/"+dependent_task_id+"/*' $HOME/tasks/$TASK_ID")
+        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/lalala $HOME/tasks/$TASK_ID")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -67,9 +67,11 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        # .with_early_script("mv $HOME/tasks/%s/* $HOME/tasks/$TASK_ID" % dependent_task_id)
-        # .with_early_script("cd $HOME/tasks/{dependent_task_id}/; for file in `ls`; mv $file $HOME/tasks/$TASK_ID")
-        .with_early_script(f"ls $HOME/tasks/{dependent_task_id}")
+        .with_caches(
+            **{
+                "lang_task_cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+            }
+        )
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
@@ -87,7 +89,7 @@ def create_build_spellers_task(dependent_task_id):
         base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/* $HOME/tasks/$TASK_ID")
+        .with_caches()
         .with_gha(
             "build_spellers",
             GithubAction(
@@ -113,8 +115,11 @@ def create_check_spellers_task(dependent_task_id):
     return (
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
-        # .with_requires(dependent_task_id)
-        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/* $HOME/tasks/$TASK_ID")
+        .with_caches(
+            **{
+                "lang_task_cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+            }
+        )
         .with_gha(
             "check_spellers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_spellers
         )
@@ -132,7 +137,11 @@ def create_build_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/* $HOME/tasks/$TASK_ID")
+        .with_caches(
+            **{
+                "lang_task_cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+            }
+        )
         .with_gha(
             "build_grammar-checkers",
             GithubAction(
@@ -155,7 +164,11 @@ def create_check_grammar_checkers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_early_script("mv $HOME/tasks/"+dependent_task_id+"/* $HOME/tasks/$TASK_ID")
+        .with_caches(
+            **{
+                "lang_task_cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+            }
+        )
         .with_gha(
             "check_grammar-checkers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_grammar_checkers
         )
@@ -166,6 +179,11 @@ def create_check_grammar_checkers_task(dependent_task_id):
 def base_lang_task(task_name, with_apertium=False):
     return (
         linux_build_task(task_name, bundle_dest="lang")
+        .with_caches(
+            **{
+                "lang_task_cache": f"${{HOME}}/tasks/${{TASK_ID}}",
+            }
+        )
         .with_additional_repo(
             "https://github.com/giellalt/giella-core.git",
             "${HOME}/tasks/${TASK_ID}/giella-core",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -1,7 +1,4 @@
-import os.path
-import yaml
-
-from gha import GithubAction, GithubActionScript
+from gha import GithubAction
 from decisionlib import CONFIG
 from .common import linux_build_task, macos_task, windows_task, NIGHTLY_CHANNEL, gha_setup
 

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -68,7 +68,8 @@ def create_check_analysers_task(dependent_task_id):
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
         # .with_early_script("mv $HOME/tasks/%s/* $HOME/tasks/$TASK_ID" % dependent_task_id)
-        .with_early_script("cd $HOME/tasks/{dependent_task_id}/; for file in `ls`; mv $file $HOME/tasks/$TASK_ID")
+        # .with_early_script("cd $HOME/tasks/{dependent_task_id}/; for file in `ls`; mv $file $HOME/tasks/$TASK_ID")
+        .with_early_script("for file in `ls $HOME/tasks/{dependent_task_id}`; mv $HOME/tasks/{dependent_task_id}/$file $HOME/tasks/$TASK_ID")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )
@@ -398,4 +399,3 @@ def create_bundle_task(os_name, type_, lang_task_id):
         )
 
     raise NotImplementedError
-

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -80,8 +80,7 @@ def create_build_spellers_task(dependent_task_id):
     task_suiffix = "-spellers-build"
 
     return (
-        # base_lang_task(task_name)
-        linux_build_task(task_name, bundle_dest="lang")
+        base_lang_task(task_name)
         .with_dependencies(dependent_task_id)
         .with_gha(
             "build_spellers",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -67,12 +67,8 @@ def create_check_analysers_task(dependent_task_id):
         linux_build_task(task_name, bundle_dest="lang")
         .with_dependencies(dependent_task_id)
         # .with_requires(dependent_task_id)
-        .with_gha(
-            "copy dependent task build folder",
-            GithubActionScript(
-                f"mv ${{HOME}}/tasks/{dependent_task_id}/* ${{HOME}}/tasks/${{TASK_ID}}"
-            ),
-        )
+        # .with_early_script("mv $HOME/tasks/%s/* $HOME/tasks/$TASK_ID" % dependent_task_id)
+        .with_early_script("cd $HOME/tasks/{dependent_task_id}/; for file in `ls`; mv $file $HOME/tasks/$TASK_ID")
         .with_gha(
             "check_analysers", GithubAction("technocreatives/divvun-taskcluster-gha-test/lang/check", {}), enabled=should_check_analysers
         )

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -147,11 +147,6 @@ def create_grammar_checkers_task(dependent_task_id):
 def base_lang_task(task_name, with_apertium=False):
     return (
         linux_build_task(task_name, bundle_dest="lang")
-        .with_caches(
-            **{
-                "divvun-lang-task-cache": "/root/tasks/${TASK_ID}",
-            }
-        )
         .with_additional_repo(
             "https://github.com/giellalt/giella-core.git",
             "${HOME}/tasks/${TASK_ID}/giella-core",


### PR DESCRIPTION
Previously all building and checking of analysers/spellers/grammar-checkers was done in a single, large build task.

This PR separates these into 3 different steps:
- Build (and optionally check) **analysers**
- Build (and optionally check) **spellers**
- Build (and optionally check) **grammar-checkers**

Building and checking for each can be enabled/disabled in language repo's `.build-config.yml` file.