### PR TITLE
Better `taskcluster-gha` branching

### DIFF
--- a/decisionlib.py
+++ b/decisionlib.py
@@ -482,9 +482,9 @@ class Task:
             **kwargs,
         )
 
-    def with_ghas(self, actions: List[Tuple[str, gha.GithubAction]], enabled=True):
+    def with_ghas(self, actions: List[Tuple[str, gha.GithubAction]], branch=None, enabled=True):
         for name, action in actions:
-            self.with_gha(name, action, enabled)
+            self.with_gha(name, action, branch, enabled)
         return self
 
     def with_gha(self, name: str, gha: gha.GithubAction, branch=None, enabled=True):
@@ -492,13 +492,19 @@ class Task:
             return self
 
         if gha.git_fetch_url and gha.git_fetch_url not in self.action_paths:
+            target = f"{gha.repo_name}-{branch}" if branch else gha.repo_name
+            print(f"target: {target}")
+
             self.with_additional_repo(
                 gha.git_fetch_url,
                 os.path.join(SHARED.task_root_for(
-                    self.platform()), gha.repo_name),
+                    self.platform()), target),
                 branch=branch
             )
-            self.action_paths.add(gha.git_fetch_url)
+
+            action_path = f"{gha.git_fetch_url}-{branch}" if branch else gha.git_fetch_url
+            print(f"action_path: {action_path}")
+            self.action_paths.add(action_path)
 
         if not any(
             CONFIG.git_ref == "refs/heads/%s" % branch for branch in DEPLOY_BRANCHES

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -491,20 +491,22 @@ class Task:
         if not enabled:
             return self
 
-        if gha.git_fetch_url and gha.git_fetch_url not in self.action_paths:
-            target = f"{gha.repo_name}-{branch}" if branch else gha.repo_name
-            print(f"target: {target}")
-
-            self.with_additional_repo(
-                gha.git_fetch_url,
-                os.path.join(SHARED.task_root_for(
-                    self.platform()), target),
-                branch=branch
-            )
-
+        if gha.git_fetch_url:
             action_path = f"{gha.git_fetch_url}-{branch}" if branch else gha.git_fetch_url
-            print(f"action_path: {action_path}")
-            self.action_paths.add(action_path)
+
+            if action_path not in self.action_paths:
+                target = f"{gha.repo_name}-{branch}" if branch else gha.repo_name
+                print(f"target: {target}")
+
+                self.with_additional_repo(
+                    gha.git_fetch_url,
+                    os.path.join(SHARED.task_root_for(
+                        self.platform()), target),
+                    branch=branch
+                )
+
+                print(f"action_path: {action_path}")
+                self.action_paths.add(action_path)
 
         if not any(
             CONFIG.git_ref == "refs/heads/%s" % branch for branch in DEPLOY_BRANCHES

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -482,9 +482,9 @@ class Task:
             **kwargs,
         )
 
-    def with_ghas(self, actions: List[Tuple[str, gha.GithubAction]], branch=None, enabled=True):
+    def with_ghas(self, actions: List[Tuple[str, gha.GithubAction]], enabled=True):
         for name, action in actions:
-            self.with_gha(name, action, branch, enabled)
+            self.with_gha(name, action, enabled)
         return self
 
     def with_gha(self, name: str, gha: gha.GithubAction, branch=None, enabled=True):
@@ -492,19 +492,13 @@ class Task:
             return self
 
         if gha.git_fetch_url and gha.git_fetch_url not in self.action_paths:
-            target = f"{gha.repo_name}-{branch}" if branch else gha.repo_name
-            print(f"target: {target}")
-
             self.with_additional_repo(
                 gha.git_fetch_url,
                 os.path.join(SHARED.task_root_for(
-                    self.platform()), target),
+                    self.platform()), gha.repo_name),
                 branch=branch
             )
-
-            action_path = f"{gha.git_fetch_url}-{branch}" if branch else gha.git_fetch_url
-            print(f"action_path: {action_path}")
-            self.action_paths.add(action_path)
+            self.action_paths.add(gha.git_fetch_url)
 
         if not any(
             CONFIG.git_ref == "refs/heads/%s" % branch for branch in DEPLOY_BRANCHES

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -491,22 +491,20 @@ class Task:
         if not enabled:
             return self
 
-        if gha.git_fetch_url:
+        if gha.git_fetch_url and gha.git_fetch_url not in self.action_paths:
+            target = f"{gha.repo_name}-{branch}" if branch else gha.repo_name
+            print(f"target: {target}")
+
+            self.with_additional_repo(
+                gha.git_fetch_url,
+                os.path.join(SHARED.task_root_for(
+                    self.platform()), target),
+                branch=branch
+            )
+
             action_path = f"{gha.git_fetch_url}-{branch}" if branch else gha.git_fetch_url
-
-            if action_path not in self.action_paths:
-                target = f"{gha.repo_name}-{branch}" if branch else gha.repo_name
-                print(f"target: {target}")
-
-                self.with_additional_repo(
-                    gha.git_fetch_url,
-                    os.path.join(SHARED.task_root_for(
-                        self.platform()), target),
-                    branch=branch
-                )
-
-                print(f"action_path: {action_path}")
-                self.action_paths.add(action_path)
+            print(f"action_path: {action_path}")
+            self.action_paths.add(action_path)
 
         if not any(
             CONFIG.git_ref == "refs/heads/%s" % branch for branch in DEPLOY_BRANCHES

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -487,18 +487,20 @@ class Task:
             self.with_gha(name, action, enabled)
         return self
 
-    def with_gha(self, name: str, gha: gha.GithubAction, branch=None, enabled=True):
+    def with_gha(self, name: str, gha: gha.GithubAction, enabled=True):
         if not enabled:
             return self
 
-        if gha.git_fetch_url and gha.git_fetch_url not in self.action_paths:
+        action_path = f"{gha.git_fetch_url}@{gha.branch}"
+
+        if gha.git_fetch_url and action_path not in self.action_paths:
             self.with_additional_repo(
                 gha.git_fetch_url,
                 os.path.join(SHARED.task_root_for(
-                    self.platform()), gha.repo_name),
-                branch=branch
+                    self.platform()), gha.repo_clone_path),
+                branch=gha.branch
             )
-            self.action_paths.add(gha.git_fetch_url)
+            self.action_paths.add(action_path)
 
         if not any(
             CONFIG.git_ref == "refs/heads/%s" % branch for branch in DEPLOY_BRANCHES

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -191,7 +191,6 @@ def base_lang_task(task_name, with_apertium=False):
 
 def create_bundle_task(os_name, type_, lang_task_id):
     if os_name == "windows-latest":
-        print("WINDOWS BUNDLE TASK")
         return (
             windows_task(f"Bundle lang: {type_}")
             .with_git()
@@ -208,6 +207,8 @@ def create_bundle_task(os_name, type_, lang_task_id):
                         "packages": "pahkat-uploader",
                     },
                 ),
+                # TODO: remove branch when done developing
+                branch="windows-codesign",
             )
             .with_gha("setup", gha_setup())
             .with_gha(
@@ -239,8 +240,6 @@ def create_bundle_task(os_name, type_, lang_task_id):
                     "divvun/taskcluster-gha/codesign",
                     { "path": "${{ steps.bundler.outputs['payload-path'] }}" },
                 ),
-                # TODO: remove branch when done developing
-                branch="windows-codesign",
             )
             .with_gha(
                 "deploy",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -254,6 +254,8 @@ def create_bundle_task(os_name, type_, lang_task_id):
                         "repo": "https://pahkat.uit.no/main/",
                         "nightly-channel": NIGHTLY_CHANNEL,
                     },
+                    # TODO: remove branch when done developing
+                    branch="windows-codesign",
                 ),
             )
             .find_or_create(f"bundle.{os_name}_x64_{type_}.{CONFIG.index_path}")

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -207,8 +207,6 @@ def create_bundle_task(os_name, type_, lang_task_id):
                         "packages": "pahkat-uploader",
                     },
                 ),
-                # TODO: remove branch when done developing
-                branch="windows-codesign",
             )
             .with_gha("setup", gha_setup())
             .with_gha(
@@ -239,6 +237,8 @@ def create_bundle_task(os_name, type_, lang_task_id):
                 GithubAction(
                     "divvun/taskcluster-gha/codesign",
                     { "path": "${{ steps.bundler.outputs['payload-path'] }}" },
+                    # TODO: remove branch when done developing
+                    branch="windows-codesign",
                 ),
             )
             .with_gha(

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -77,9 +77,9 @@ def create_analysers_task(with_apertium):
         .with_gha(
             "test",
             GithubAction(
-                "divvun/taskcluster-gha/test", {}
+                "divvun/taskcluster-gha/test", {},
+                branch="windows-codesign" 
             ),
-            branch="windows-codesign" 
         )
         .with_gha(
             "check_analysers",

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -73,14 +73,6 @@ def create_analysers_task(with_apertium):
                 }
             )
         )
-        # TODO: remove this test action when done testing branches
-        .with_gha(
-            "test",
-            GithubAction(
-                "divvun/taskcluster-gha/test", {},
-                branch="windows-codesign" 
-            ),
-        )
         .with_gha(
             "check_analysers",
             GithubAction(

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -73,6 +73,14 @@ def create_analysers_task(with_apertium):
                 }
             )
         )
+        # TODO: remove this test action when done testing branches
+        .with_gha(
+            "test",
+            GithubAction(
+                "divvun/taskcluster-gha/test", {}
+            ),
+            branch="windows-codesign" 
+        )
         .with_gha(
             "check_analysers",
             GithubAction(

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -183,6 +183,7 @@ def base_lang_task(task_name, with_apertium=False):
 
 def create_bundle_task(os_name, type_, lang_task_id):
     if os_name == "windows-latest":
+        print("WINDOWS BUNDLE TASK")
         return (
             windows_task(f"Bundle lang: {type_}")
             .with_git()
@@ -199,8 +200,6 @@ def create_bundle_task(os_name, type_, lang_task_id):
                         "packages": "pahkat-uploader",
                     },
                 ),
-                # TODO: remove branch when done developing
-                branch="windows-codesign",
             )
             .with_gha("setup", gha_setup())
             .with_gha(
@@ -232,6 +231,8 @@ def create_bundle_task(os_name, type_, lang_task_id):
                     "divvun/taskcluster-gha/codesign",
                     { "path": "${{ steps.bundler.outputs['payload-path'] }}" },
                 ),
+                # TODO: remove branch when done developing
+                branch="windows-codesign",
             )
             .with_gha(
                 "deploy",


### PR DESCRIPTION
Improve using branches with `taskcluster-gha`.

Currently it's possible to use a branch, but it's a bit of a hack and only works if the branch is specified in the very first call to a given taskcluster-gha repo.

This PR makes it possible to specify a branch on a per-gha call basis. This means multiple branches of the same `taskcluster-gha` repo may be used at the same time.

Usage looks like this:

```python
...
# Since no branch is specified in the `GithubAction` below, `main` will be used
.with_gha(
    "bundler",
    GithubAction(
        "divvun/taskcluster-gha/speller/bundle",
        {
            "speller-type": type_,
            "speller-manifest-path": "manifest.toml",
            "speller-paths": "${{ steps.build_spellers.outputs['speller-paths'] }}",
            "version": "${{ steps.version.outputs.version }}",
        },
    ).with_outputs_from(lang_task_id),
)
# This action will use the `windows-codesign` branch
.with_gha(
    "codesign",
    GithubAction(
        "divvun/taskcluster-gha/codesign",
        { "path": "${{ steps.bundler.outputs['payload-path'] }}" },
        # TODO: remove branch when done developing
        branch="windows-codesign",
    ),
)
# This action will use the `other-branch` branch
.with_gha(
    "deploy",
    GithubAction(
        "divvun/taskcluster-gha/speller/deploy",
        {
            "speller-type": type_,
            "speller-manifest-path": "manifest.toml",
            "payload-path": "${{ steps.codesign.outputs['signed-path'] }}",
            "version": "${{ steps.version.outputs.version }}",
            "channel": "${{ steps.version.outputs.channel }}",
            "repo": "https://pahkat.uit.no/main/",
            "nightly-channel": NIGHTLY_CHANNEL,
        },
        # TODO: remove branch when done developing
        branch="windows-codesign",
    ),
)
...
```