### PR TITLE
Codesign During Build Step on Windows

### DIFF
--- a/gha.py
+++ b/gha.py
@@ -19,7 +19,7 @@ class GithubAction:
             self.version = "master"
 
         self.args = {}
-        self.branch = branch
+        self.branch = "fix-divvun-manager-windows"
 
         # FIXME: temporary hack to attempt fixing the checkout action
         if path and path == "actions/checkout":

--- a/gha.py
+++ b/gha.py
@@ -19,11 +19,15 @@ class GithubAction:
             self.version = "master"
 
         self.args = {}
-        self.branch = "fix-divvun-manager-windows"
+        self.branch = branch
 
         # FIXME: temporary hack to attempt fixing the checkout action
         if path and path == "actions/checkout":
             self.branch = "releases/v4.0.0"
+
+        # TODO: remove this when done testing
+        if path and "taskcluster-gha" in path:
+            self.branch = "fix-divvun-manager-windows"
             
         self.post_path = None
         self.run_path = "index.js"

--- a/gha.py
+++ b/gha.py
@@ -24,10 +24,6 @@ class GithubAction:
         # FIXME: temporary hack to attempt fixing the checkout action
         if path and path == "actions/checkout":
             self.branch = "releases/v4.0.0"
-
-        # TODO: remove this when done testing
-        if path and "taskcluster-gha" in path:
-            self.branch = "fix-divvun-manager-windows"
             
         self.post_path = None
         self.run_path = "index.js"

--- a/tasks/kbd_task.py
+++ b/tasks/kbd_task.py
@@ -39,19 +39,12 @@ def create_kbd_task(os_name):
                 ),
             )
             .with_gha(
-                "codesign",
-                GithubAction(
-                    "divvun/taskcluster-gha/codesign",
-                    { "path": "${{ steps.build.outputs['payload-path'] }}" },
-                ),
-            )
-            .with_gha(
                 "upload",
                 GithubAction(
                     "divvun/taskcluster-gha/keyboard/deploy",
                     {
                         "keyboard-type": "keyboard-windows",
-                        "payload-path": "${{ steps.codesign.outputs['signed-path'] }}",
+                        "payload-path": "${{ steps.build.outputs['payload-path'] }}",
                         "channel": "${{ steps.build.outputs.channel }}",
                     },
                 ),

--- a/tasks/lang_task.py
+++ b/tasks/lang_task.py
@@ -225,20 +225,13 @@ def create_bundle_task(os_name, type_, lang_task_id):
                 ).with_outputs_from(lang_task_id),
             )
             .with_gha(
-                "codesign",
-                GithubAction(
-                    "divvun/taskcluster-gha/codesign",
-                    { "path": "${{ steps.bundler.outputs['payload-path'] }}" },
-                ),
-            )
-            .with_gha(
                 "deploy",
                 GithubAction(
                     "divvun/taskcluster-gha/speller/deploy",
                     {
                         "speller-type": type_,
                         "speller-manifest-path": "manifest.toml",
-                        "payload-path": "${{ steps.codesign.outputs['signed-path'] }}",
+                        "payload-path": "${{ steps.bundler.outputs['payload-path'] }}",
                         "version": "${{ steps.version.outputs.version }}",
                         "channel": "${{ steps.version.outputs.channel }}",
                         "repo": "https://pahkat.uit.no/main/",


### PR DESCRIPTION
This PR removes the `codesign` step for `lang-*` and `keyboard-*` repos on Windows. This step is no longer necessary now that signing takes place during the build step via Inno Setup.

See: https://github.com/divvun/taskcluster-gha/pull/11 for more details.