### PR TITLE
Support private repos

### DIFF
--- a/decision_task.py
+++ b/decision_task.py
@@ -12,6 +12,7 @@ from tasks import *
 
 
 def tasks(task_for: str):
+    print("ON BRANCH: private-repos") # TODO: remove when done testing
     repo_name = os.environ["REPO_NAME"]
     if "[ci skip]" in CONFIG.commit_message:
         print("Skipping CI")

--- a/decision_task.py
+++ b/decision_task.py
@@ -11,9 +11,6 @@ import decisionlib
 from decisionlib import CONFIG
 from tasks import *
 
-import runner
-runner.gather_secrets()
-
 def tasks(task_for: str):
     print("ON BRANCH: private-repos") # TODO: remove when done testing
     repo_name = os.environ["REPO_NAME"]

--- a/decision_task.py
+++ b/decision_task.py
@@ -5,15 +5,16 @@ only thing called from a `.taskcluster.yml`, if you need new tasks, add them
 here in the right section.
 """
 
-from runner import gather_secrets
-gather_secrets()
-
 import os
 import os.path
 import decisionlib
 from decisionlib import CONFIG
 from tasks import *
 
+from runner import filtered_print
+from runner import gather_secrets
+print = filtered_print
+gather_secrets()
 
 def tasks(task_for: str):
     print("ON BRANCH: private-repos") # TODO: remove when done testing

--- a/decision_task.py
+++ b/decision_task.py
@@ -9,9 +9,11 @@ import os.path
 import decisionlib
 from decisionlib import CONFIG
 from tasks import *
+from runner import gather_secrets
 
 
 def tasks(task_for: str):
+    gather_secrets()
     print("ON BRANCH: private-repos") # TODO: remove when done testing
     repo_name = os.environ["REPO_NAME"]
     if "[ci skip]" in CONFIG.commit_message:

--- a/decision_task.py
+++ b/decision_task.py
@@ -11,9 +11,9 @@ from decisionlib import CONFIG
 from tasks import *
 from runner import gather_secrets
 
+gather_secrets()
 
 def tasks(task_for: str):
-    gather_secrets()
     print("ON BRANCH: private-repos") # TODO: remove when done testing
     repo_name = os.environ["REPO_NAME"]
     if "[ci skip]" in CONFIG.commit_message:

--- a/decision_task.py
+++ b/decision_task.py
@@ -14,76 +14,6 @@ from typing import Set, Any
 from taskcluster import helper
 
 
-SECRETS: Set[str] = set()
-_ORIG_PRINT = print
-
-def filtered_print(*args):
-    """
-    This function is designed to replace the original print function to avoid
-    accidental secret leaks. It'll replace all secrets contained in the
-    `SECRETS` global variable with `[*******]`.
-    """
-    filtered = []
-    for arg in args:
-        for secret in SECRETS:
-            arg = str(arg).replace(secret, "[******]")
-        filtered.append(arg)
-    try:
-        _ORIG_PRINT(*filtered)
-    except UnicodeEncodeError:
-        _ORIG_PRINT("[Unicode decode error]")
-
-
-print = filtered_print
-
-
-def gather_secrets():
-    """
-    Gather all available secrets from taskcluster and put them into the global
-    `SECRETS` variable. This should be called quite early to avoid accidental
-    secrets leaking.
-    """
-    secrets_service = helper.TaskclusterConfig().get_service("secrets")
-    secret_names: Set[str] = set()
-
-    def get_values_from_json(obj: Any) -> Set[str]:
-        """
-        Returns a list of values contained in a JSON object by recursively traversing it.
-        """
-        out = set()
-
-        def flatten(x):
-            if isinstance(x, dict):
-                for value in x.values():
-                    flatten(value)
-            elif isinstance(x, list):
-                for value in x:
-                    flatten(value)
-            else:
-                out.add(x)
-
-        flatten(obj)
-        return out
-
-    continuation = None
-    while True:
-        res = secrets_service.list(continuationToken=continuation)
-        secret_names.update(set(res["secrets"]))
-        if not res.get("continuationToken"):
-            break
-        continuation = res["continuationToken"]
-
-    for name in secret_names:
-        try:
-            res = secrets_service.get(name)
-            SECRETS.update(get_values_from_json(res["secret"]))
-        except:
-            # This happens when we're not allowed to read the secret. Unfortunately
-            # there's no way of filtering out secrets we can't read from the
-            # listing so we have to try to get them all.
-            pass
-
-
 def tasks(task_for: str):
     print("ON BRANCH: private-repos") # TODO: remove when done testing
     repo_name = os.environ["REPO_NAME"]
@@ -190,6 +120,75 @@ def tasks(task_for: str):
     if repo_name == "macdivvun-service":
         create_macdivvun_task()
 
+
+SECRETS: Set[str] = set()
+_ORIG_PRINT = print
+
+def filtered_print(*args):
+    """
+    This function is designed to replace the original print function to avoid
+    accidental secret leaks. It'll replace all secrets contained in the
+    `SECRETS` global variable with `[*******]`.
+    """
+    filtered = []
+    for arg in args:
+        for secret in SECRETS:
+            arg = str(arg).replace(secret, "[******]")
+        filtered.append(arg)
+    try:
+        _ORIG_PRINT(*filtered)
+    except UnicodeEncodeError:
+        _ORIG_PRINT("[Unicode decode error]")
+
+
+print = filtered_print
+
+
+def gather_secrets():
+    """
+    Gather all available secrets from taskcluster and put them into the global
+    `SECRETS` variable. This should be called quite early to avoid accidental
+    secrets leaking.
+    """
+    secrets_service = helper.TaskclusterConfig().get_service("secrets")
+    secret_names: Set[str] = set()
+
+    def get_values_from_json(obj: Any) -> Set[str]:
+        """
+        Returns a list of values contained in a JSON object by recursively traversing it.
+        """
+        out = set()
+
+        def flatten(x):
+            if isinstance(x, dict):
+                for value in x.values():
+                    flatten(value)
+            elif isinstance(x, list):
+                for value in x:
+                    flatten(value)
+            else:
+                out.add(x)
+
+        flatten(obj)
+        return out
+
+    continuation = None
+    while True:
+        res = secrets_service.list(continuationToken=continuation)
+        secret_names.update(set(res["secrets"]))
+        if not res.get("continuationToken"):
+            break
+        continuation = res["continuationToken"]
+
+    for name in secret_names:
+        try:
+            res = secrets_service.get(name)
+            SECRETS.update(get_values_from_json(res["secret"]))
+        except:
+            # This happens when we're not allowed to read the secret. Unfortunately
+            # there's no way of filtering out secrets we can't read from the
+            # listing so we have to try to get them all.
+            pass
 
 gather_secrets()
 

--- a/decision_task.py
+++ b/decision_task.py
@@ -14,6 +14,76 @@ from typing import Set, Any
 from taskcluster import helper
 
 
+SECRETS: Set[str] = set()
+_ORIG_PRINT = print
+
+def filtered_print(*args):
+    """
+    This function is designed to replace the original print function to avoid
+    accidental secret leaks. It'll replace all secrets contained in the
+    `SECRETS` global variable with `[*******]`.
+    """
+    filtered = []
+    for arg in args:
+        for secret in SECRETS:
+            arg = str(arg).replace(secret, "[******]")
+        filtered.append(arg)
+    try:
+        _ORIG_PRINT(*filtered)
+    except UnicodeEncodeError:
+        _ORIG_PRINT("[Unicode decode error]")
+
+
+print = filtered_print
+
+
+def gather_secrets():
+    """
+    Gather all available secrets from taskcluster and put them into the global
+    `SECRETS` variable. This should be called quite early to avoid accidental
+    secrets leaking.
+    """
+    secrets_service = helper.TaskclusterConfig().get_service("secrets")
+    secret_names: Set[str] = set()
+
+    def get_values_from_json(obj: Any) -> Set[str]:
+        """
+        Returns a list of values contained in a JSON object by recursively traversing it.
+        """
+        out = set()
+
+        def flatten(x):
+            if isinstance(x, dict):
+                for value in x.values():
+                    flatten(value)
+            elif isinstance(x, list):
+                for value in x:
+                    flatten(value)
+            else:
+                out.add(x)
+
+        flatten(obj)
+        return out
+
+    continuation = None
+    while True:
+        res = secrets_service.list(continuationToken=continuation)
+        secret_names.update(set(res["secrets"]))
+        if not res.get("continuationToken"):
+            break
+        continuation = res["continuationToken"]
+
+    for name in secret_names:
+        try:
+            res = secrets_service.get(name)
+            SECRETS.update(get_values_from_json(res["secret"]))
+        except:
+            # This happens when we're not allowed to read the secret. Unfortunately
+            # there's no way of filtering out secrets we can't read from the
+            # listing so we have to try to get them all.
+            pass
+
+
 def tasks(task_for: str):
     print("ON BRANCH: private-repos") # TODO: remove when done testing
     repo_name = os.environ["REPO_NAME"]
@@ -120,75 +190,6 @@ def tasks(task_for: str):
     if repo_name == "macdivvun-service":
         create_macdivvun_task()
 
-
-SECRETS: Set[str] = set()
-_ORIG_PRINT = print
-
-def filtered_print(*args):
-    """
-    This function is designed to replace the original print function to avoid
-    accidental secret leaks. It'll replace all secrets contained in the
-    `SECRETS` global variable with `[*******]`.
-    """
-    filtered = []
-    for arg in args:
-        for secret in SECRETS:
-            arg = str(arg).replace(secret, "[******]")
-        filtered.append(arg)
-    try:
-        _ORIG_PRINT(*filtered)
-    except UnicodeEncodeError:
-        _ORIG_PRINT("[Unicode decode error]")
-
-
-print = filtered_print
-
-
-def gather_secrets():
-    """
-    Gather all available secrets from taskcluster and put them into the global
-    `SECRETS` variable. This should be called quite early to avoid accidental
-    secrets leaking.
-    """
-    secrets_service = helper.TaskclusterConfig().get_service("secrets")
-    secret_names: Set[str] = set()
-
-    def get_values_from_json(obj: Any) -> Set[str]:
-        """
-        Returns a list of values contained in a JSON object by recursively traversing it.
-        """
-        out = set()
-
-        def flatten(x):
-            if isinstance(x, dict):
-                for value in x.values():
-                    flatten(value)
-            elif isinstance(x, list):
-                for value in x:
-                    flatten(value)
-            else:
-                out.add(x)
-
-        flatten(obj)
-        return out
-
-    continuation = None
-    while True:
-        res = secrets_service.list(continuationToken=continuation)
-        secret_names.update(set(res["secrets"]))
-        if not res.get("continuationToken"):
-            break
-        continuation = res["continuationToken"]
-
-    for name in secret_names:
-        try:
-            res = secrets_service.get(name)
-            SECRETS.update(get_values_from_json(res["secret"]))
-        except:
-            # This happens when we're not allowed to read the secret. Unfortunately
-            # there's no way of filtering out secrets we can't read from the
-            # listing so we have to try to get them all.
-            pass
 
 gather_secrets()
 

--- a/decision_task.py
+++ b/decision_task.py
@@ -12,7 +12,6 @@ from tasks import *
 
 
 def tasks(task_for: str):
-    print("ON BRANCH: private-repos") # TODO: remove when done testing
     repo_name = os.environ["REPO_NAME"]
     if "[ci skip]" in CONFIG.commit_message:
         print("Skipping CI")

--- a/decision_task.py
+++ b/decision_task.py
@@ -4,14 +4,16 @@ creating all of the other tasks for a repository's CI. It should always be the
 only thing called from a `.taskcluster.yml`, if you need new tasks, add them
 here in the right section.
 """
+
+from runner import gather_secrets
+gather_secrets()
+
 import os
 import os.path
 import decisionlib
 from decisionlib import CONFIG
 from tasks import *
-from runner import gather_secrets
 
-gather_secrets()
 
 def tasks(task_for: str):
     print("ON BRANCH: private-repos") # TODO: remove when done testing

--- a/decision_task.py
+++ b/decision_task.py
@@ -11,10 +11,8 @@ import decisionlib
 from decisionlib import CONFIG
 from tasks import *
 
-from runner import filtered_print
-from runner import gather_secrets
-print = filtered_print
-gather_secrets()
+import runner
+runner.gather_secrets()
 
 def tasks(task_for: str):
     print("ON BRANCH: private-repos") # TODO: remove when done testing

--- a/decision_task.py
+++ b/decision_task.py
@@ -4,12 +4,12 @@ creating all of the other tasks for a repository's CI. It should always be the
 only thing called from a `.taskcluster.yml`, if you need new tasks, add them
 here in the right section.
 """
-
 import os
 import os.path
 import decisionlib
 from decisionlib import CONFIG
 from tasks import *
+
 
 def tasks(task_for: str):
     print("ON BRANCH: private-repos") # TODO: remove when done testing

--- a/decision_task.py
+++ b/decision_task.py
@@ -10,9 +10,9 @@ import os.path
 import decisionlib
 from decisionlib import CONFIG
 from tasks import *
-from typing import Set, Any
-from taskcluster import helper
 
+import runner
+runner.gather_secrets()
 
 def tasks(task_for: str):
     print("ON BRANCH: private-repos") # TODO: remove when done testing
@@ -120,77 +120,6 @@ def tasks(task_for: str):
     if repo_name == "macdivvun-service":
         create_macdivvun_task()
 
-
-SECRETS: Set[str] = set()
-_ORIG_PRINT = print
-
-def filtered_print(*args):
-    """
-    This function is designed to replace the original print function to avoid
-    accidental secret leaks. It'll replace all secrets contained in the
-    `SECRETS` global variable with `[*******]`.
-    """
-    filtered = []
-    for arg in args:
-        for secret in SECRETS:
-            arg = str(arg).replace(secret, "[******]")
-        filtered.append(arg)
-    try:
-        _ORIG_PRINT(*filtered)
-    except UnicodeEncodeError:
-        _ORIG_PRINT("[Unicode decode error]")
-
-
-print = filtered_print
-
-
-def gather_secrets():
-    """
-    Gather all available secrets from taskcluster and put them into the global
-    `SECRETS` variable. This should be called quite early to avoid accidental
-    secrets leaking.
-    """
-    secrets_service = helper.TaskclusterConfig().get_service("secrets")
-    secret_names: Set[str] = set()
-
-    def get_values_from_json(obj: Any) -> Set[str]:
-        """
-        Returns a list of values contained in a JSON object by recursively traversing it.
-        """
-        out = set()
-
-        def flatten(x):
-            if isinstance(x, dict):
-                for value in x.values():
-                    flatten(value)
-            elif isinstance(x, list):
-                for value in x:
-                    flatten(value)
-            else:
-                out.add(x)
-
-        flatten(obj)
-        return out
-
-    continuation = None
-    while True:
-        res = secrets_service.list(continuationToken=continuation)
-        secret_names.update(set(res["secrets"]))
-        if not res.get("continuationToken"):
-            break
-        continuation = res["continuationToken"]
-
-    for name in secret_names:
-        try:
-            res = secrets_service.get(name)
-            SECRETS.update(get_values_from_json(res["secret"]))
-        except:
-            # This happens when we're not allowed to read the secret. Unfortunately
-            # there's no way of filtering out secrets we can't read from the
-            # listing so we have to try to get them all.
-            pass
-
-gather_secrets()
 
 task_for = os.environ["TASK_FOR"]
 repo_name = os.environ["REPO_NAME"]

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -29,8 +29,10 @@ import gha
 import utils
 import yaml
 
+# The decision task needs access to secrets in order to support private repos.
+# Replace standard print with filtered_print and gather_secrets (as in runner.py) 
+# to prevent accidental secrets leaking
 from runner import filtered_print, gather_secrets
-
 print = filtered_print
 gather_secrets()
 

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -119,8 +119,6 @@ class Config:
 
             sec = secrets()
             token = sec["github"]["token"] 
-            print("TEST_SECRET:")
-            print(sec["TEST_SECRET"])
             headers = {
                 "Authorization": f"token {token}",
                 "Accept": "application/vnd.github.v3.patch",

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -135,7 +135,7 @@ class Config:
             try:
                 url = f"https://raw.githubusercontent.com/{os.environ['REPO_FULL_NAME']}/{self.git_sha}/.build-config.yml" 
                 sec = secrets()
-                token = secrets["github"]["token"] 
+                token = sec["github"]["token"] 
                 headers = {
                     "Authorization": f"token {token}",
                     "Accept": "application/vnd.github.v3.raw",

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -32,7 +32,7 @@ import yaml
 # The decision task needs access to secrets in order to support private repos.
 # Replace standard print with filtered_print and gather_secrets (as in runner.py) 
 # to prevent accidental secrets leaking
-from utils import test_secret, secrets
+from utils import github_token 
 from runner import filtered_print, gather_secrets
 print = filtered_print
 gather_secrets()
@@ -117,13 +117,8 @@ class Config:
             url = f"https://api.github.com/repos/{os.environ['REPO_FULL_NAME']}/commits/{self.git_sha}"
             print(url)
 
-            print("TEST_SECRET FROM OTHER MODULE:")
-            print(test_secret())
-
-            sec = secrets()
-            token = sec["github"]["token"] 
             headers = {
-                "Authorization": f"token {token}",
+                "Authorization": f"token {github_token()}",
                 "Accept": "application/vnd.github.v3.patch",
             }
             commit = requests.get(url, headers=headers).text
@@ -137,10 +132,8 @@ class Config:
         if self._tc_config is None:
             try:
                 url = f"https://raw.githubusercontent.com/{os.environ['REPO_FULL_NAME']}/{self.git_sha}/.build-config.yml" 
-                sec = secrets()
-                token = sec["github"]["token"] 
                 headers = {
-                    "Authorization": f"token {token}",
+                    "Authorization": f"token {github_token()}",
                     "Accept": "application/vnd.github.v3.raw",
                 }
                 config = requests.get(url, headers=headers).text

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -32,7 +32,7 @@ import yaml
 # The decision task needs access to secrets in order to support private repos.
 # Replace standard print with filtered_print and gather_secrets (as in runner.py) 
 # to prevent accidental secrets leaking
-from utils import secrets
+from utils import test_secret, secrets
 from runner import filtered_print, gather_secrets
 print = filtered_print
 gather_secrets()
@@ -116,6 +116,9 @@ class Config:
             print("Getting commit message")
             url = f"https://api.github.com/repos/{os.environ['REPO_FULL_NAME']}/commits/{self.git_sha}"
             print(url)
+
+            print("TEST_SECRET FROM OTHER MODULE:")
+            print(test_secret())
 
             sec = secrets()
             token = sec["github"]["token"] 

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -131,8 +131,14 @@ class Config:
     def tc_config(self):
         if self._tc_config is None:
             try:
-                config = requests.get(
-                    f"https://raw.githubusercontent.com/{os.environ['REPO_FULL_NAME']}/{self.git_sha}/.build-config.yml").text
+                url = f"https://raw.githubusercontent.com/{os.environ['REPO_FULL_NAME']}/{self.git_sha}/.build-config.yml" 
+                secrets = get_secret()
+                token = secrets["github"]["token"] 
+                headers = {
+                    "Authorization": f"token {token}",
+                    "Accept": "application/vnd.github.v3.raw",
+                }
+                config = requests.get(url, headers=headers).text
                 self._tc_config = yaml.load(config, Loader=yaml.FullLoader)
             except yaml.YAMLError:
                 raise

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -116,8 +116,6 @@ class Config:
 
             secrets = get_secret()
             token = secrets["github"]["token"] 
-            print("test secret:")
-            print(secrets["TEST_SECRET"])
 
             headers = {
                 "Authorization": f"token {token}",

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -32,6 +32,7 @@ import yaml
 # The decision task needs access to secrets in order to support private repos.
 # Replace standard print with filtered_print and gather_secrets (as in runner.py) 
 # to prevent accidental secrets leaking
+from utils import secrets
 from runner import filtered_print, gather_secrets
 print = filtered_print
 gather_secrets()
@@ -116,9 +117,10 @@ class Config:
             url = f"https://api.github.com/repos/{os.environ['REPO_FULL_NAME']}/commits/{self.git_sha}"
             print(url)
 
-            secrets = get_secret()
-            token = secrets["github"]["token"] 
-
+            sec = secrets()
+            token = sec["github"]["token"] 
+            print("TEST_SECRET:")
+            print(sec["TEST_SECRET"])
             headers = {
                 "Authorization": f"token {token}",
                 "Accept": "application/vnd.github.v3.patch",
@@ -134,7 +136,7 @@ class Config:
         if self._tc_config is None:
             try:
                 url = f"https://raw.githubusercontent.com/{os.environ['REPO_FULL_NAME']}/{self.git_sha}/.build-config.yml" 
-                secrets = get_secret()
+                sec = secrets()
                 token = secrets["github"]["token"] 
                 headers = {
                     "Authorization": f"token {token}",
@@ -151,14 +153,6 @@ class Config:
 
         return self._tc_config
 
-
-def get_secret():
-    client = taskcluster.Secrets({
-        "rootUrl": os.environ["TASKCLUSTER_PROXY_URL"] 
-    })
-    secrets = client.get("divvun")
-    loadedSecrets = secrets["secret"]
-    return loadedSecrets
 
 class Shared:
     """

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -116,6 +116,8 @@ class Config:
 
             secrets = get_secret()
             token = secrets["github"]["token"] 
+            print("test secret:")
+            print(secrets["TEST_SECRET"])
 
             headers = {
                 "Authorization": f"token {token}",

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -110,6 +110,8 @@ class Config:
             print(
                 f"https://github.com/{os.environ['REPO_FULL_NAME']}/commit/{self.git_sha}.patch"
             )
+            print("Attempting to get secret:")
+            print(get_secret())
             commit = requests.get(
                 f"https://github.com/{os.environ['REPO_FULL_NAME']}/commit/{self.git_sha}.patch"
             ).text
@@ -134,6 +136,11 @@ class Config:
 
         return self._tc_config
 
+
+def get_secret():
+    client = taskcluster.Secrets()
+    secret = client.get("divvun")["TEST_SECRET"]
+    return secret
 
 class Shared:
     """

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -138,7 +138,9 @@ class Config:
 
 
 def get_secret():
-    client = taskcluster.Secrets()
+    client = taskcluster.Secrets({
+        "rootUrl": os.environ["TASKCLUSTER_PROXY_URL"] 
+    })
     secret = client.get("divvun")["TEST_SECRET"]
     return secret
 

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -111,14 +111,16 @@ class Config:
     def commit_message(self):
         if self._commit_message is None:
             print("Getting commit message")
-            print(
-                f"https://github.com/{os.environ['REPO_FULL_NAME']}/commit/{self.git_sha}.patch"
-            )
-            print("Attempting to get secret:")
-            print(get_secret())
-            commit = requests.get(
-                f"https://github.com/{os.environ['REPO_FULL_NAME']}/commit/{self.git_sha}.patch"
-            ).text
+            url = f"https://github.com/{os.environ['REPO_FULL_NAME']}/commit/{self.git_sha}.patch" 
+            print(url)
+
+            token = get_secret("github.token")
+
+            headers = {
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github.v3.patch",
+            }
+            commit = requests.get(url, headers=headers).text
             print(commit)
             self._commit_message = commit.split("diff --git a/")[0]
             print(self._commit_message)
@@ -141,13 +143,13 @@ class Config:
         return self._tc_config
 
 
-def get_secret():
+def get_secret(key):
     client = taskcluster.Secrets({
         "rootUrl": os.environ["TASKCLUSTER_PROXY_URL"] 
     })
     secrets = client.get("divvun")
     loadedSecrets = secrets["secret"]
-    secret = loadedSecrets["TEST_SECRET"]
+    secret = loadedSecrets[key]
     return secret
 
 class Shared:

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -142,7 +142,7 @@ def get_secret():
         "rootUrl": os.environ["TASKCLUSTER_PROXY_URL"] 
     })
     secrets = client.get("divvun")
-    loadedSecrets = secrets.secret
+    loadedSecrets = secrets["secret"]
     secret = loadedSecrets["TEST_SECRET"]
     return secret
 

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -122,7 +122,7 @@ class Config:
                 "Accept": "application/vnd.github.v3.patch",
             }
             commit = requests.get(url, headers=headers).text
-            print(commit)
+            # print(commit)
             self._commit_message = commit.split("diff --git a/")[0]
             print(self._commit_message)
         return self._commit_message

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -29,6 +29,10 @@ import gha
 import utils
 import yaml
 
+from runner import filtered_print, gather_secrets
+
+print = filtered_print
+gather_secrets()
 
 # Public API
 __all__ = [

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -114,7 +114,8 @@ class Config:
             url = f"https://github.com/{os.environ['REPO_FULL_NAME']}/commit/{self.git_sha}.patch" 
             print(url)
 
-            token = get_secret("github.token")
+            secrets = get_secret()
+            token = secrets["github"]["token"] 
 
             headers = {
                 "Authorization": f"token {token}",
@@ -143,14 +144,13 @@ class Config:
         return self._tc_config
 
 
-def get_secret(key):
+def get_secret():
     client = taskcluster.Secrets({
         "rootUrl": os.environ["TASKCLUSTER_PROXY_URL"] 
     })
     secrets = client.get("divvun")
     loadedSecrets = secrets["secret"]
-    secret = loadedSecrets[key]
-    return secret
+    return loadedSecrets
 
 class Shared:
     """

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -141,7 +141,9 @@ def get_secret():
     client = taskcluster.Secrets({
         "rootUrl": os.environ["TASKCLUSTER_PROXY_URL"] 
     })
-    secret = client.get("divvun")["TEST_SECRET"]
+    secrets = client.get("divvun")
+    loadedSecrets = secrets.secret
+    secret = loadedSecrets["TEST_SECRET"]
     return secret
 
 class Shared:

--- a/decisionlib.py
+++ b/decisionlib.py
@@ -111,7 +111,7 @@ class Config:
     def commit_message(self):
         if self._commit_message is None:
             print("Getting commit message")
-            url = f"https://github.com/{os.environ['REPO_FULL_NAME']}/commit/{self.git_sha}.patch" 
+            url = f"https://api.github.com/repos/{os.environ['REPO_FULL_NAME']}/commits/{self.git_sha}"
             print(url)
 
             secrets = get_secret()

--- a/utils.py
+++ b/utils.py
@@ -78,3 +78,7 @@ def secrets():
     secrets = client.get("divvun")
     loadedSecrets = secrets["secret"]
     return loadedSecrets
+
+def test_secret():
+    sec = secrets()
+    return sec["TEST_SECRET"]

--- a/utils.py
+++ b/utils.py
@@ -69,3 +69,12 @@ def create_extra_artifact(path: str, content: bytes, public=False):
     result = loop.run_until_complete(coro)
     loop.close()
     return result
+
+
+def secrets():
+    client = taskcluster.Secrets({
+        "rootUrl": os.environ["TASKCLUSTER_PROXY_URL"] 
+    })
+    secrets = client.get("divvun")
+    loadedSecrets = secrets["secret"]
+    return loadedSecrets

--- a/utils.py
+++ b/utils.py
@@ -79,6 +79,7 @@ def secrets():
     loadedSecrets = secrets["secret"]
     return loadedSecrets
 
-def test_secret():
+
+def github_token():
     sec = secrets()
-    return sec["TEST_SECRET"]
+    return sec["github"]["token"]


### PR DESCRIPTION
Adds support for private repos to be processed by Taskcluster. 

Updates the fetching of `.build-config.yml` as well as commit diffs to use authentication so that private repos may be seen.

See https://github.com/divvun/maintenance2023/issues/50